### PR TITLE
Add randU gate type

### DIFF
--- a/src/quantumcircuit/quantumgates.jl
+++ b/src/quantumcircuit/quantumgates.jl
@@ -242,6 +242,15 @@ gate(::GateName"CCCNOT") =
    0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0]
 
 #
+# n-qubit gates
+#
+
+function gate(::GateName"randU", N::Int)
+  Q, _ = NDTensors.qr_positive(randn(ComplexF64, N, N))
+  return Q
+end
+
+#
 # State preparation gates
 #
 
@@ -380,9 +389,14 @@ gate(::GateName{gn}; kwargs...) where {gn} =
 
 gate(s::String) = gate(GateName(s))
 
+# Version that accepts a dimension for the gate,
+# for n-qubit gates
+gate(gn::GateName, N::Int; kwargs...) =
+  gate(gn; kwargs...)
+
 function gate(gn::GateName, s::Index...; kwargs...)
   rs = reverse(s)
-  g = gate(gn; kwargs...) 
+  g = gate(gn, dim(s); kwargs...) 
   if ndims(g) == 1
     return itensor(g, rs...)
   elseif ndims(g) == 2

--- a/test/quantumgates.jl
+++ b/test/quantumgates.jl
@@ -160,7 +160,27 @@ using LinearAlgebra
   ggdag = g * prime(dag(g),plev=1,1)
   @test array(ggdag) ≈ reshape(Matrix{ComplexF64}(I, 4, 4),(2,2,2,2))
  
+  g = gate("randU", i)
+  @test hasinds(g, i', i)
+  Id = g * swapprime(dag(g)', 2 => 1)
+  for n in 1:dim(i), n′ in 1:dim(i)
+    if n == n′
+      @test Id[n, n′] ≈ 1
+    else
+      @test Id[n, n′] ≈ 0 atol = 1e-15
+    end
+  end
+
+  g = gate("randU", i, j)
+  @test hasinds(g, i', j', i, j)
+  Id = g * swapprime(dag(g)', 2 => 1)
+  for n in 1:dim(i), m in 1:dim(j), n′ in 1:dim(i), m′ in 1:dim(j)
+    if (n, m) == (n′, m′)
+      @test Id[n, m, n′, m′] ≈ 1
+    else
+      @test Id[n, m, n′, m′] ≈ 0 atol = 1e-15
+    end
+  end
+
 end
-
-
 


### PR DESCRIPTION
This adds a `"randU"` gate type as described in #59. It works for general number of indices, i.e. `gate("randU", s1, s2, s3)` makes a random unitary on 3 qubits. Closes #59.

The unitaries are Haar-distributed, as described in Section 4.6 of http://math.mit.edu/~edelman/publications/random_matrix_theory.pdf.