### PR TITLE
Change process tomography samples data format

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,14 +181,14 @@ unitary circuit (noiseless) or the Choi matrix (noisy).
 
 ```julia
 # 2c) Generate data for quantum process tomography, consisting of input states
-# (data_in) to a quantum channel, and the corresponding projective measurements
+# to a quantum channel, and the corresponding projective measurements
 # at the output. By defaul, the states prepared at the inputs are selected from
 # product states of eigenstates of Pauli operators, while measurements bases are
 # sampled from the Pauli group.
 
 # Unitary channel, returns the MPO unitary circuit
-data_in, data_out, U = getsamples(N, gates, nshots; process=true)
+data, U = getsamples(N, gates, nshots; process=true)
 
 # Noisy channel, returns the Choi matrix
-data_in, data_out, Λ = getsamples(N, gates, nshots; process = true, noise = ("amplitude_damping", (γ = 0.01,)))
+data, Λ = getsamples(N, gates, nshots; process = true, noise = ("amplitude_damping", (γ = 0.01,)))
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -182,16 +182,16 @@ unitary circuit (noiseless) or the Choi matrix (noisy).
 
 ```julia
 # 2c) Generate data for quantum process tomography, consisting of input states
-# (data_in) to a quantum channel, and the corresponding projective measurements
-# at the output. By defaul, the states prepared at the inputs are selected from
+# to a quantum channel, and the corresponding projective measurements
+# at the output. By default, the states prepared at the inputs are selected from
 # product states of eigenstates of Pauli operators, while measurements bases are
 # sampled from the Pauli group.
 
 # Unitary channel, returns the MPO unitary circuit
-data_in, data_out, U = getsamples(N, gates, nshots; process=true)
+data, U = getsamples(N, gates, nshots; process=true)
 
 # Noisy channel, returns the Choi matrix
-data_in, data_out, Λ = generatedata(N, gates, nshots; process = true, noise = ("amplitude_damping", (γ = 0.01,)))
+data, Λ = generatedata(N, gates, nshots; process = true, noise = ("amplitude_damping", (γ = 0.01,)))
 ```
 
 

--- a/examples/2_datageneration.jl
+++ b/examples/2_datageneration.jl
@@ -19,7 +19,7 @@ data, ψ = getsamples(N, gates, nshots)
 # Returns output state as MPS
 @show maxlinkdim(ψ)
 @show ψ 
-writedata(data, ψ, "data/qst_circuit.h5")
+writesamples(data, ψ, "data/qst_circuit.h5")
 
 # Note: the above is equivalent to:
 #> bases = randombases(N,nshots,localbasis=["X","Y","Z"])
@@ -32,7 +32,7 @@ data, ρ = getsamples(N, gates, nshots;
 # Return the mixed density operator as MPO
 @show maxlinkdim(ρ)
 @show ρ
-writedata(data, ρ, "data/qst_circuit_noisy.h5")
+writesamples(data, ρ, "data/qst_circuit_noisy.h5")
 
 # 2. Generation of measurerment data for quantum process
 # tomography. Each measurement consist of a input product 
@@ -44,7 +44,7 @@ data, U = getsamples(N, gates, nshots;
 # Return the MPO for the unitary circuit
 @show maxlinkdim(U)
 @show U
-writedata(data, U, "data/qpt_circuit.h5")
+writesamples(data, U, "data/qpt_circuit.h5")
 
 data, Λ = getsamples(N, gates, nshots;
                                   process = true,
@@ -52,5 +52,5 @@ data, Λ = getsamples(N, gates, nshots;
 # Return the Choi matrix `Λ` as MPO wiith `2N` sites
 @show maxlinkdim(Λ.M)
 @show Λ
-writedata(data, Λ, "data/qpt_circuit_noisy.h5")
+writesamples(data, Λ, "data/qpt_circuit_noisy.h5")
 

--- a/examples/2_datageneration.jl
+++ b/examples/2_datageneration.jl
@@ -19,7 +19,7 @@ data, ψ = getsamples(N, gates, nshots)
 # Returns output state as MPS
 @show maxlinkdim(ψ)
 @show ψ 
-savedata(data, ψ, "data/qst_circuit.h5")
+writedata(data, ψ, "data/qst_circuit.h5")
 
 # Note: the above is equivalent to:
 #> bases = randombases(N,nshots,localbasis=["X","Y","Z"])
@@ -32,7 +32,7 @@ data, ρ = getsamples(N, gates, nshots;
 # Return the mixed density operator as MPO
 @show maxlinkdim(ρ)
 @show ρ
-savedata(data, ρ, "data/qst_circuit_noisy.h5")
+writedata(data, ρ, "data/qst_circuit_noisy.h5")
 
 # 2. Generation of measurerment data for quantum process
 # tomography. Each measurement consist of a input product 
@@ -44,7 +44,7 @@ data, U = getsamples(N, gates, nshots;
 # Return the MPO for the unitary circuit
 @show maxlinkdim(U)
 @show U
-savedata(data, U, "data/qpt_circuit.h5")
+writedata(data, U, "data/qpt_circuit.h5")
 
 data, Λ = getsamples(N, gates, nshots;
                                   process = true,
@@ -52,5 +52,5 @@ data, Λ = getsamples(N, gates, nshots;
 # Return the Choi matrix `Λ` as MPO wiith `2N` sites
 @show maxlinkdim(Λ.M)
 @show Λ
-savedata(data, Λ, "data/qpt_circuit_noisy.h5")
+writedata(data, Λ, "data/qpt_circuit_noisy.h5")
 

--- a/examples/2_datageneration.jl
+++ b/examples/2_datageneration.jl
@@ -39,18 +39,18 @@ savedata(data, ρ, "data/qst_circuit_noisy.h5")
 # state and an output projective measurement in a arbitrary
 # local basis. By default, the single-qubit input states are 
 # the 6 eigenstates of Pauli operators.
-data_in, data_out, U = getsamples(N, gates, nshots;
+data, U = getsamples(N, gates, nshots;
                                   process = true)
 # Return the MPO for the unitary circuit
 @show maxlinkdim(U)
 @show U
-savedata(data_in, data_out, U, "data/qpt_circuit.h5")
+savedata(data, U, "data/qpt_circuit.h5")
 
-data_in, data_out, Λ = getsamples(N, gates, nshots;
+data, Λ = getsamples(N, gates, nshots;
                                   process = true,
                                   noise = ("amplitude_damping", (γ = 0.01,)))
 # Return the Choi matrix `Λ` as MPO wiith `2N` sites
 @show maxlinkdim(Λ.M)
 @show Λ
-savedata(data_in, data_out, Λ, "data/qpt_circuit_noisy.h5")
+savedata(data, Λ, "data/qpt_circuit_noisy.h5")
 

--- a/examples/3_qst_circuit.jl
+++ b/examples/3_qst_circuit.jl
@@ -8,7 +8,7 @@ Random.seed!(1234)
 # as the output of a unitary quantum circuit
 
 # Load target state and measurement data
-data, Ψ = readdata("data/qst_circuit.h5")
+data, Ψ = readsamples("data/qst_circuit.h5")
 
 # Set parameters 
 N = length(Ψ)     # Number of qubits
@@ -35,7 +35,7 @@ opt = SGD(η = 0.01)
 # as the output of a noisy quantum circuit
 
 # Load target state and measurement data
-data, ϱ = readdata("data/qst_circuit_noisy.h5")
+data, ϱ = readsamples("data/qst_circuit_noisy.h5")
 
 # Set parameters
 N = length(ϱ)     # Number of qubits

--- a/examples/3_qst_circuit.jl
+++ b/examples/3_qst_circuit.jl
@@ -8,7 +8,7 @@ Random.seed!(1234)
 # as the output of a unitary quantum circuit
 
 # Load target state and measurement data
-data, Ψ = loaddata("data/qst_circuit.h5")
+data, Ψ = readdata("data/qst_circuit.h5")
 
 # Set parameters 
 N = length(Ψ)     # Number of qubits
@@ -35,7 +35,7 @@ opt = SGD(η = 0.01)
 # as the output of a noisy quantum circuit
 
 # Load target state and measurement data
-data, ϱ = loaddata("data/qst_circuit_noisy.h5")
+data, ϱ = readdata("data/qst_circuit_noisy.h5")
 
 # Set parameters
 N = length(ϱ)     # Number of qubits

--- a/examples/4_qpt_circuit.jl
+++ b/examples/4_qpt_circuit.jl
@@ -9,7 +9,7 @@ Random.seed!(1234)
 # Load target state and measurements. Each samples is built out
 # of an input state (`first.(data)`) to the quantum channel, and the
 # measurement output (`last.(data)`) after a local basis rotation.
-data, Û = loaddata("data/qpt_circuit.h5")
+data, Û = readdata("data/qpt_circuit.h5")
 
 # Set parameters
 N = length(Û)     # Number of qubits
@@ -32,7 +32,7 @@ U = tomography(data, U0;
 # Noisy circuit
 Random.seed!(1234)
 # Load data and target Choi matrix
-data, Φ = loaddata("data/qpt_circuit_noisy.h5")
+data, Φ = readdata("data/qpt_circuit_noisy.h5")
 N = length(Φ)
 χ = 8
 ξ = 2

--- a/examples/4_qpt_circuit.jl
+++ b/examples/4_qpt_circuit.jl
@@ -7,9 +7,9 @@ Random.seed!(1234)
 # 1. Quantum process tomography of a unitary circuit
 
 # Load target state and measurements. Each samples is built out
-# of a input state (`data_in`) to the quantum channel, and the
-# measurement output (`data_out`) after a local basis rotation.
-data_in, data_out, Û = loaddata("data/qpt_circuit.h5"; process = true)
+# of an input state (`first.(data)`) to the quantum channel, and the
+# measurement output (`last.(data)`) after a local basis rotation.
+data, Û = loaddata("data/qpt_circuit.h5")
 
 # Set parameters
 N = length(Û)     # Number of qubits
@@ -22,7 +22,7 @@ U0 = randomprocess(N; χ = χ)
 @show maxlinkdim(U0)
 
 # Run process tomography
-U = tomography(data_in, data_out, U0;
+U = tomography(data, U0;
                optimizer = SGD(η = 0.1),
                batchsize = 500,
                epochs = 5,
@@ -32,7 +32,7 @@ U = tomography(data_in, data_out, U0;
 # Noisy circuit
 Random.seed!(1234)
 # Load data and target Choi matrix
-data_in, data_out, Φ = loaddata("data/qpt_circuit_noisy.h5"; process = true)
+data, Φ = loaddata("data/qpt_circuit_noisy.h5")
 N = length(Φ)
 χ = 8
 ξ = 2
@@ -44,7 +44,7 @@ N = length(Φ)
 opt = SGD(η = 0.1)
 
 # Run process tomography
-Λ = tomography(data_in, data_out, Λ0;
+Λ = tomography(data, Λ0;
                optimizer = opt,
                mixed = true,
                batchsize = 500,

--- a/examples/4_qpt_circuit.jl
+++ b/examples/4_qpt_circuit.jl
@@ -9,7 +9,7 @@ Random.seed!(1234)
 # Load target state and measurements. Each samples is built out
 # of an input state (`first.(data)`) to the quantum channel, and the
 # measurement output (`last.(data)`) after a local basis rotation.
-data, Û = readdata("data/qpt_circuit.h5")
+data, Û = readsamples("data/qpt_circuit.h5")
 
 # Set parameters
 N = length(Û)     # Number of qubits
@@ -32,7 +32,7 @@ U = tomography(data, U0;
 # Noisy circuit
 Random.seed!(1234)
 # Load data and target Choi matrix
-data, Φ = readdata("data/qpt_circuit_noisy.h5")
+data, Φ = readsamples("data/qpt_circuit_noisy.h5")
 N = length(Φ)
 χ = 8
 ξ = 2

--- a/src/PastaQ.jl
+++ b/src/PastaQ.jl
@@ -18,7 +18,7 @@ include("choi.jl")
 include("circuits/gates.jl")
 include("circuits/circuits.jl")
 include("circuits/runcircuit.jl")
-include("circuits/datagen.jl")
+include("circuits/getsamples.jl")
 
 include("optimizers.jl")
 include("observer.jl")

--- a/src/circuits/getsamples.jl
+++ b/src/circuits/getsamples.jl
@@ -221,7 +221,6 @@ basis rotation is performed at the output of a quantum channel.
  - `prep`: a prepared input state (e.g. `["X+","Z-","Y+","X-"]`)
  - `basis`: a measuremement basis (e.g. `["Z","Z","Y","X"])
 """
-# Generate a single data point for process tomography
 function getsamples(M0::Union{MPS,MPO},
                     gate_tensors::Vector{<:ITensor},
                     prep::Array, basis::Array;
@@ -348,7 +347,7 @@ function getsamples(N::Int64, gates::Vector{<:Tuple}, nshots::Int64;
         measurement = getsamples!(M_meas; readout_errors = readout_errors)
         data[n,:] =  convertdatapoint(measurement,bases[n,:])
       end
-      return preps, data, M
+      return preps .=> data, M
     
     # Generate data with full state evolution
     else
@@ -363,7 +362,7 @@ function getsamples(N::Int64, gates::Vector{<:Tuple}, nshots::Int64;
                                maxdim = maxdim, readout_errors = readout_errors,
                                kwargs...)
       end
-      return preps, data
+      return preps .=> data
     end
   end
 end

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -62,5 +62,5 @@ export
   
 # utils.jl
   # Methods
-  savedata,
-  loaddata
+  writedata,
+  readdata

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -62,5 +62,5 @@ export
   
 # utils.jl
   # Methods
-  writedata,
-  readdata
+  writesamples,
+  readsamples

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,5 +1,5 @@
 """
-    writedata(data::Matrix, model::Union{MPS, MPO, LPDO, Choi},
+    writesamples(data::Matrix, model::Union{MPS, MPO, LPDO, Choi},
               output_path::String)
 
 Save data and model on file:
@@ -9,7 +9,7 @@ Save data and model on file:
   - `model`: MPS, MPO, or Choi
   - `output_path`: path to file
 """
-function writedata(data::Matrix,
+function writesamples(data::Matrix,
                    model::Union{MPS, MPO, LPDO, Choi},
                    output_path::String)
   # Make the path the file will sit in, if it doesn't exist
@@ -20,7 +20,7 @@ function writedata(data::Matrix,
   end
 end
 
-function writedata(data::Matrix{<: Pair},
+function writesamples(data::Matrix{<: Pair},
                    model::Union{MPS, MPO, LPDO, Choi},
                    output_path::String)
   # Make the path the file will sit in, if it doesn't exist
@@ -33,14 +33,14 @@ function writedata(data::Matrix{<: Pair},
 end
 
 """
-    readdata(input_path::String)
+    readsamples(input_path::String)
 
 Load data and model from file:
 
 # Arguments:
   - `input_path`: path to file
 """
-function readdata(input_path::String)
+function readsamples(input_path::String)
   fin = h5open(input_path, "r")
   g = g_open(fin, "model")
   typestring = read(attrs(g)["type"])

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -21,29 +21,6 @@ function savedata(data::Matrix,
 end
 
 """
-    savedata(data::Matrix{Pair{String, String}},
-             model::Union{MPS,MPO,Choi},
-             output_path::String)
-
-Save data and model on file:
-
-# Arguments:
-  - `data` : array of pairs of preparation states and measurement data
-  - `model`: MPS, MPO, or Choi
-  - `output_path`: path to file
-"""
-function savedata(data::Matrix{Pair{String, String}},
-                  model::Union{MPO,Choi},
-                  output_path::String)
-  # Make the path the file will sit in, if it doesn't exist
-  mkpath(dirname(output_path))
-  h5rewrite(output_path) do fout
-    write(fout, "data", data)
-    write(fout, "model", model)
-  end
-end
-
-"""
     loaddata(input_path::String)
 
 Load data and model from file:

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,5 +1,5 @@
 """
-    savedata(data::Matrix, model::Union{MPS,MPO,Choi},
+    writedata(data::Matrix, model::Union{MPS,MPO,Choi},
              output_path::String)
 
 Save data and model on file:
@@ -9,7 +9,7 @@ Save data and model on file:
   - `model`: MPS, MPO, or Choi
   - `output_path`: path to file
 """
-function savedata(data::Matrix,
+function writedata(data::Matrix,
                   model::Union{MPS,MPO,LPDO},
                   output_path::String)
   # Make the path the file will sit in, if it doesn't exist
@@ -21,14 +21,14 @@ function savedata(data::Matrix,
 end
 
 """
-    loaddata(input_path::String)
+    readdata(input_path::String)
 
 Load data and model from file:
 
 # Arguments:
   - `input_path`: path to file
 """
-function loaddata(input_path::String)
+function readdata(input_path::String)
   fin = h5open(input_path,"r")
   
   g = g_open(fin,"model")

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,5 +1,5 @@
 """
-    savedata(data::Array, model::Union{MPS,MPO,Choi},
+    savedata(data::Matrix, model::Union{MPS,MPO,Choi},
              output_path::String)
 
 Save data and model on file:
@@ -9,7 +9,7 @@ Save data and model on file:
   - `model`: MPS, MPO, or Choi
   - `output_path`: path to file
 """
-function savedata(data::Array,
+function savedata(data::Matrix,
                   model::Union{MPS,MPO,LPDO},
                   output_path::String)
   # Make the path the file will sit in, if it doesn't exist
@@ -21,43 +21,37 @@ function savedata(data::Array,
 end
 
 """
-    savedata(data_in::Array,
-             data_out::Array,
+    savedata(data::Matrix{Pair{String, String}},
              model::Union{MPS,MPO,Choi},
              output_path::String)
 
 Save data and model on file:
 
 # Arguments:
-  - `data_in` : array of preparation states
-  - `data_out`: array of measurement data
+  - `data` : array of pairs of preparation states and measurement data
   - `model`: MPS, MPO, or Choi
   - `output_path`: path to file
 """
-function savedata(data_in::Array,
-                  data_out::Array,
+function savedata(data::Matrix{Pair{String, String}},
                   model::Union{MPO,Choi},
                   output_path::String)
   # Make the path the file will sit in, if it doesn't exist
   mkpath(dirname(output_path))
   h5rewrite(output_path) do fout
-    write(fout,"data_in",data_in)
-    write(fout,"data_out",data_out)
-    write(fout,"model",model)
+    write(fout, "data", data)
+    write(fout, "model", model)
   end
 end
 
 """
-    loaddata(input_path::String;process::Bool=false)
+    loaddata(input_path::String)
 
 Load data and model from file:
 
 # Arguments:
   - `input_path`: path to file
-  - `process`: if `true`, data is treated as coming from measuring a process, and loads both input and output data
 """
-
-function loaddata(input_path::String; process::Bool = false)
+function loaddata(input_path::String)
   fin = h5open(input_path,"r")
   
   g = g_open(fin,"model")
@@ -65,16 +59,9 @@ function loaddata(input_path::String; process::Bool = false)
   modeltype = eval(Meta.parse(typestring))
   model = read(fin, "model", modeltype)
   
-  if process
-    data_in = read(fin,"data_in")
-    data_out = read(fin,"data_out")
-    close(fin)
-    return data_in, data_out, model
-  else
-    data = read(fin,"data")
-    close(fin)
-    return data, model
-  end
+  data = read(fin,"data")
+  close(fin)
+  return data, model
 end
 
 """

--- a/test/datagen.jl
+++ b/test/datagen.jl
@@ -5,6 +5,10 @@ using JLD
 using Test
 using LinearAlgebra
 
+#
+# Helper functions for tests
+#
+
 function state_to_int(state::Array)
   index = 0
   for j in 1:length(state)
@@ -12,8 +16,6 @@ function state_to_int(state::Array)
   end
   return index
 end
-
-
 
 function empiricalprobability(samples::Matrix)
   prob = zeros((1<<size(samples)[2]))
@@ -23,17 +25,6 @@ function empiricalprobability(samples::Matrix)
     prob[index+1] += 1
   end
   prob = prob / size(samples)[1]
-  return prob
-end
-
-function probability_of(data_in::Array,data_out::Array,target_in::Array,target_out::Array)
-  nshots = size(data_in)[1]
-  prob = 0.0
-  for n in 1:nshots
-    if data_in[n,:]==target_in && data_out[n,:]==target_out
-      prob += 1.0/nshots
-    end
-  end
   return prob
 end
 
@@ -307,21 +298,19 @@ end
                        localbasis = ["X","Y","Z"])
   
   # 4) Process tomography
-  data_in, data_out = getsamples(N, gates, nshots; process = true, build_process = false)
-  @test size(data_in) == (nshots,N)
-  @test size(data_out) == (nshots,N)
-  data_in,data_out = getsamples(N, gates, nshots;
-                                process = true,
-                                build_process = false,
-                                noise = ("amplitude_damping", (γ = 0.1,)))
-  @test size(data_in) == (nshots,N)
-  @test size(data_out) == (nshots,N)
-  data_in, data_out, Λ  = getsamples(N, gates, nshots; process = true, build_process = true)
+  data = getsamples(N, gates, nshots; process = true, build_process = false)
+  @test size(data) == (nshots,N)
+  data = getsamples(N, gates, nshots;
+                    process = true,
+                    build_process = false,
+                    noise = ("amplitude_damping", (γ = 0.1,)))
+  @test size(data) == (nshots,N)
+  data, Λ  = getsamples(N, gates, nshots; process = true, build_process = true)
   @test Λ isa MPO
-  data_in, data_out, Λ = getsamples(N, gates, nshots;
-                                    process = true,
-                                    build_process = true,
-                                    noise = ("amplitude_damping", (γ = 0.1,)))
+  data, Λ = getsamples(N, gates, nshots;
+                       process = true,
+                       build_process = true,
+                       noise = ("amplitude_damping", (γ = 0.1,)))
   @test Λ isa Choi{MPO}
 
 end
@@ -376,20 +365,24 @@ end
                        readout_errors = readout_errors)
   
   # 4) Process tomography
-  data_in, data_out = getsamples(N,gates,nshots;process=true,build_process=false, readout_errors = readout_errors)
-  @test size(data_in) == (nshots,N)
-  @test size(data_out) == (nshots,N)
-  data_in, data_out = getsamples(N, gates, nshots;
-                                 process = true,
-                                 build_process = false,
-                                 noise = ("amplitude_damping", (γ = 0.1,)),
-                                 readout_errors = readout_errors)
-  @test size(data_in) == (nshots,N)
-  @test size(data_out) == (nshots,N)
-  data_in, data_out, Λ = getsamples(N, gates, nshots; process = true, build_process = true, readout_errors = readout_errors)
-  data_in, data_out, Λ = getsamples(N, gates, nshots;
-                                    process = true,
-                                    build_process = true,
-                                    noise = ("amplitude_damping", (γ = 0.1,)),
-                                    readout_errors = readout_errors)
+  data = getsamples(N, gates, nshots;
+                    process = true,
+                    build_process = false,
+                    readout_errors = readout_errors)
+  @test size(data) == (nshots,N)
+  data = getsamples(N, gates, nshots;
+                    process = true,
+                    build_process = false,
+                    noise = ("amplitude_damping", (γ = 0.1,)),
+                    readout_errors = readout_errors)
+  @test size(data) == (nshots,N)
+  data, Λ = getsamples(N, gates, nshots;
+                       process = true,
+                       build_process = true,
+                       readout_errors = readout_errors)
+  data, Λ = getsamples(N, gates, nshots;
+                       process = true,
+                       build_process = true,
+                       noise = ("amplitude_damping", (γ = 0.1,)),
+                       readout_errors = readout_errors)
 end

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -22,14 +22,14 @@ data, ρ = getsamples(N, gates, nshots;
                      noise = ("amplitude_damping", (γ = 0.01,)))
 savedata(data, ρ, "../examples/data/qst_circuit_noisy_test.h5")
 
-data_in, data_out, U = getsamples(N,gates,nshots;
-                                  process=true)
-savedata(data_in, data_out, U, "../examples/data/qpt_circuit_test.h5")
+data, U = getsamples(N, gates, nshots;
+                     process = true)
+savedata(data, U, "../examples/data/qpt_circuit_test.h5")
 
-data_in, data_out, Λ = getsamples(N,gates,nshots;
-                                  process = true,
-                                  noise = ("amplitude_damping", (γ = 0.01,)))
-savedata(data_in, data_out, Λ, "../examples/data/qpt_circuit_noisy_test.h5")
+data, Λ = getsamples(N,gates,nshots;
+                     process = true,
+                     noise = ("amplitude_damping", (γ = 0.01,)))
+savedata(data, Λ, "../examples/data/qpt_circuit_noisy_test.h5")
 
 
 Random.seed!(1234)
@@ -58,12 +58,12 @@ opt = SGD(η = 0.01)
                target = ϱ)
 
 Random.seed!(1234)
-data_in, data_out, U = loaddata("../examples/data/qpt_circuit_test.h5"; process = true)
+data, U = loaddata("../examples/data/qpt_circuit_test.h5"; process = true)
 N = length(U)     # Number of qubits
 χ = maxlinkdim(U) # Bond dimension of variational MPS
 V0 = randomprocess(U; χ = χ)
 opt = SGD(η = 0.1)
-V = tomography(data_in, data_out, V0;
+V = tomography(data, V0;
                optimizer = opt,
                batchsize = 100,
                epochs = 2,
@@ -71,13 +71,13 @@ V = tomography(data_in, data_out, V0;
 
 # Noisy circuit
 Random.seed!(1234)
-data_in, data_out, ϱ = loaddata("../examples/data/qpt_circuit_noisy_test.h5"; process = true)
+data, ϱ = loaddata("../examples/data/qpt_circuit_noisy_test.h5"; process = true)
 N = length(ϱ)
 χ = 8
 ξ = 2
 Λ0 = randomprocess(ϱ; mixed = true, χ = χ, ξ = ξ, σ = 0.1)
 opt = SGD(η = 0.1)
-Λ = tomography(data_in, data_out, Λ0;
+Λ = tomography(data, Λ0;
                optimizer = opt,
                mixed = true,
                batchsize = 10,

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -16,24 +16,24 @@ U = runcircuit(N, gates; process = true)
 Random.seed!(1234)
 nshots = 100
 data, ψ = getsamples(N, gates, nshots)
-writedata(data, ψ, "../examples/data/qst_circuit_test.h5")
+writesamples(data, ψ, "../examples/data/qst_circuit_test.h5")
 
 data, ρ = getsamples(N, gates, nshots;
                      noise = ("amplitude_damping", (γ = 0.01,)))
-writedata(data, ρ, "../examples/data/qst_circuit_noisy_test.h5")
+writesamples(data, ρ, "../examples/data/qst_circuit_noisy_test.h5")
 
 data, U = getsamples(N, gates, nshots;
                      process = true)
-writedata(data, U, "../examples/data/qpt_circuit_test.h5")
+writesamples(data, U, "../examples/data/qpt_circuit_test.h5")
 
 data, Λ = getsamples(N,gates,nshots;
                      process = true,
                      noise = ("amplitude_damping", (γ = 0.01,)))
-writedata(data, Λ, "../examples/data/qpt_circuit_noisy_test.h5")
+writesamples(data, Λ, "../examples/data/qpt_circuit_noisy_test.h5")
 
 
 Random.seed!(1234)
-data, Ψ = readdata("../examples/data/qst_circuit_test.h5")
+data, Ψ = readsamples("../examples/data/qst_circuit_test.h5")
 N = length(Ψ)     # Number of qubits
 χ = maxlinkdim(Ψ) # Bond dimension of variational MPS
 ψ0 = randomstate(Ψ; χ = χ, σ = 0.1)
@@ -44,7 +44,7 @@ opt = SGD(η = 0.01)
                epochs = 2,
                target = Ψ)
 
-data, ϱ = readdata("../examples/data/qst_circuit_noisy_test.h5")
+data, ϱ = readsamples("../examples/data/qst_circuit_noisy_test.h5")
 N = length(ϱ)     # Number of qubits
 χ = maxlinkdim(ϱ) # Bond dimension of variational LPDO
 ξ = 2             # Kraus dimension of variational LPDO
@@ -58,7 +58,7 @@ opt = SGD(η = 0.01)
                target = ϱ)
 
 Random.seed!(1234)
-data, U = readdata("../examples/data/qpt_circuit_test.h5")
+data, U = readsamples("../examples/data/qpt_circuit_test.h5")
 N = length(U)     # Number of qubits
 χ = maxlinkdim(U) # Bond dimension of variational MPS
 V0 = randomprocess(U; χ = χ)
@@ -71,7 +71,7 @@ V = tomography(data, V0;
 
 # Noisy circuit
 Random.seed!(1234)
-data, ϱ = readdata("../examples/data/qpt_circuit_noisy_test.h5")
+data, ϱ = readsamples("../examples/data/qpt_circuit_noisy_test.h5")
 N = length(ϱ)
 χ = 8
 ξ = 2

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -58,7 +58,7 @@ opt = SGD(η = 0.01)
                target = ϱ)
 
 Random.seed!(1234)
-data, U = readdata("../examples/data/qpt_circuit_test.h5"; process = true)
+data, U = readdata("../examples/data/qpt_circuit_test.h5")
 N = length(U)     # Number of qubits
 χ = maxlinkdim(U) # Bond dimension of variational MPS
 V0 = randomprocess(U; χ = χ)
@@ -71,7 +71,7 @@ V = tomography(data, V0;
 
 # Noisy circuit
 Random.seed!(1234)
-data, ϱ = readdata("../examples/data/qpt_circuit_noisy_test.h5"; process = true)
+data, ϱ = readdata("../examples/data/qpt_circuit_noisy_test.h5")
 N = length(ϱ)
 χ = 8
 ξ = 2

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -16,24 +16,24 @@ U = runcircuit(N, gates; process = true)
 Random.seed!(1234)
 nshots = 100
 data, ψ = getsamples(N, gates, nshots)
-savedata(data, ψ, "../examples/data/qst_circuit_test.h5")
+writedata(data, ψ, "../examples/data/qst_circuit_test.h5")
 
 data, ρ = getsamples(N, gates, nshots;
                      noise = ("amplitude_damping", (γ = 0.01,)))
-savedata(data, ρ, "../examples/data/qst_circuit_noisy_test.h5")
+writedata(data, ρ, "../examples/data/qst_circuit_noisy_test.h5")
 
 data, U = getsamples(N, gates, nshots;
                      process = true)
-savedata(data, U, "../examples/data/qpt_circuit_test.h5")
+writedata(data, U, "../examples/data/qpt_circuit_test.h5")
 
 data, Λ = getsamples(N,gates,nshots;
                      process = true,
                      noise = ("amplitude_damping", (γ = 0.01,)))
-savedata(data, Λ, "../examples/data/qpt_circuit_noisy_test.h5")
+writedata(data, Λ, "../examples/data/qpt_circuit_noisy_test.h5")
 
 
 Random.seed!(1234)
-data, Ψ = loaddata("../examples/data/qst_circuit_test.h5")
+data, Ψ = readdata("../examples/data/qst_circuit_test.h5")
 N = length(Ψ)     # Number of qubits
 χ = maxlinkdim(Ψ) # Bond dimension of variational MPS
 ψ0 = randomstate(Ψ; χ = χ, σ = 0.1)
@@ -44,7 +44,7 @@ opt = SGD(η = 0.01)
                epochs = 2,
                target = Ψ)
 
-data, ϱ = loaddata("../examples/data/qst_circuit_noisy_test.h5")
+data, ϱ = readdata("../examples/data/qst_circuit_noisy_test.h5")
 N = length(ϱ)     # Number of qubits
 χ = maxlinkdim(ϱ) # Bond dimension of variational LPDO
 ξ = 2             # Kraus dimension of variational LPDO
@@ -58,7 +58,7 @@ opt = SGD(η = 0.01)
                target = ϱ)
 
 Random.seed!(1234)
-data, U = loaddata("../examples/data/qpt_circuit_test.h5"; process = true)
+data, U = readdata("../examples/data/qpt_circuit_test.h5"; process = true)
 N = length(U)     # Number of qubits
 χ = maxlinkdim(U) # Bond dimension of variational MPS
 V0 = randomprocess(U; χ = χ)
@@ -71,7 +71,7 @@ V = tomography(data, V0;
 
 # Noisy circuit
 Random.seed!(1234)
-data, ϱ = loaddata("../examples/data/qpt_circuit_noisy_test.h5"; process = true)
+data, ϱ = readdata("../examples/data/qpt_circuit_noisy_test.h5"; process = true)
 N = length(ϱ)
 χ = 8
 ξ = 2

--- a/test/observer.jl
+++ b/test/observer.jl
@@ -6,7 +6,7 @@ using Test
 
 @testset "observer output" begin
   Random.seed!(1234)
-  data,Ψ = loaddata("../examples/data/qst_circuit_test.h5")
+  data,Ψ = readdata("../examples/data/qst_circuit_test.h5")
   N = length(Ψ)     # Number of qubits
   χ = maxlinkdim(Ψ) # Bond dimension of variational MPS
   ψ0 = randomstate(Ψ; χ = χ, σ = 0.1)
@@ -23,7 +23,7 @@ using Test
   @test length(obs.frobenius_distance) == 0
   @test length(obs.negative_loglikelihood) == 3
   
-  data, ϱ = loaddata("../examples/data/qst_circuit_noisy_test.h5")
+  data, ϱ = readdata("../examples/data/qst_circuit_noisy_test.h5")
   N = length(ϱ)     # Number of qubits
   χ = maxlinkdim(ϱ) # Bond dimension of variational LPDO
   ξ = 2             # Kraus dimension of variational LPDO
@@ -40,7 +40,7 @@ using Test
   @test length(obs.frobenius_distance) == 3
   @test length(obs.negative_loglikelihood) == 3
   
-  data, U = loaddata("../examples/data/qpt_circuit_test.h5")
+  data, U = readdata("../examples/data/qpt_circuit_test.h5")
   N = length(U)     # Number of qubits
   χ = maxlinkdim(U) # Bond dimension of variational MPS
   opt = SGD(η = 0.1)
@@ -59,7 +59,7 @@ using Test
   
   # Noisy circuit
   Random.seed!(1234)
-  data, ϱ = loaddata("../examples/data/qpt_circuit_noisy_test.h5")
+  data, ϱ = readdata("../examples/data/qpt_circuit_noisy_test.h5")
   N = length(ϱ)
   χ = 8
   ξ = 2

--- a/test/observer.jl
+++ b/test/observer.jl
@@ -9,14 +9,14 @@ using Test
   data,Ψ = loaddata("../examples/data/qst_circuit_test.h5")
   N = length(Ψ)     # Number of qubits
   χ = maxlinkdim(Ψ) # Bond dimension of variational MPS
-  ψ0 = randomstate(Ψ;χ=χ,σ=0.1)
+  ψ0 = randomstate(Ψ; χ = χ, σ = 0.1)
   opt = SGD(η = 0.01)
-  ψ,obs = tomography(data, ψ0;
-               optimizer=opt,
-               batchsize = 10,
-               epochs = 3,
-               target = Ψ,
-               record=true);
+  ψ, obs = tomography(data, ψ0;
+                      optimizer = opt,
+                      batchsize = 10,
+                      epochs = 3,
+                      target = Ψ,
+                      record = true);
   
   @test length(obs.fidelity) == 3
   @test length(obs.fidelity_bound) == 0
@@ -27,30 +27,30 @@ using Test
   N = length(ϱ)     # Number of qubits
   χ = maxlinkdim(ϱ) # Bond dimension of variational LPDO
   ξ = 2             # Kraus dimension of variational LPDO
-  ρ0 = randomstate(ϱ;mixed=true,χ=χ,ξ=ξ,σ=0.1)
+  ρ0 = randomstate(ϱ; mixed = true, χ = χ, ξ = ξ, σ = 0.1)
   opt = SGD(η = 0.01)
-  ρ,obs = tomography(data,ρ0;
-                     optimizer=opt,
-                     batchsize=10,
-                     epochs=3,
-                     target=ϱ,
-                     record=true);
+  ρ, obs = tomography(data,ρ0;
+                      optimizer = opt,
+                      batchsize = 10,
+                      epochs = 3,
+                      target = ϱ,
+                      record = true);
   @test length(obs.fidelity) == 3
   @test length(obs.fidelity_bound) == 3
   @test length(obs.frobenius_distance) == 3
   @test length(obs.negative_loglikelihood) == 3
   
-  data_in, data_out, U = loaddata("../examples/data/qpt_circuit_test.h5";process=true)
+  data, U = loaddata("../examples/data/qpt_circuit_test.h5")
   N = length(U)     # Number of qubits
   χ = maxlinkdim(U) # Bond dimension of variational MPS
   opt = SGD(η = 0.1)
-  V0 = randomprocess(U;mixed=false,χ=χ)
-  V,obs = tomography(data_in,data_out,V0;
-                     optimizer=opt,
-                     batchsize=10,
-                     epochs=3,
-                     target=U,
-                     record=true)
+  V0 = randomprocess(U; mixed = false, χ = χ)
+  V, obs = tomography(data, V0;
+                      optimizer = opt,
+                      batchsize = 10,
+                      epochs = 3,
+                      target = U,
+                      record = true)
 
   @test length(obs.fidelity) == 3
   @test length(obs.fidelity_bound) == 0
@@ -59,19 +59,19 @@ using Test
   
   # Noisy circuit
   Random.seed!(1234)
-  data_in,data_out, ϱ = loaddata("../examples/data/qpt_circuit_noisy_test.h5";process=true)
+  data, ϱ = loaddata("../examples/data/qpt_circuit_noisy_test.h5")
   N = length(ϱ)
   χ = 8
   ξ = 2
-  Λ0 = randomprocess(ϱ;mixed=true,χ=χ,ξ=ξ,σ=0.1)
+  Λ0 = randomprocess(ϱ; mixed = true, χ = χ, ξ = ξ, σ = 0.1)
   opt = SGD(η = 0.1)
-  Λ,obs = tomography(data_in,data_out,Λ0;
-                     optimizer=opt,
-                     mixed=true,
-                     batchsize=10,
-                     epochs=3,
-                     target=ϱ,
-                     record=true);
+  Λ, obs = tomography(data, Λ0;
+                      optimizer = opt,
+                      mixed = true,
+                      batchsize = 10,
+                      epochs = 3,
+                      target = ϱ,
+                      record = true);
   @test length(obs.fidelity) == 3
   @test length(obs.fidelity_bound) == 3
   @test length(obs.frobenius_distance) == 3

--- a/test/observer.jl
+++ b/test/observer.jl
@@ -6,7 +6,7 @@ using Test
 
 @testset "observer output" begin
   Random.seed!(1234)
-  data,Ψ = readdata("../examples/data/qst_circuit_test.h5")
+  data,Ψ = readsamples("../examples/data/qst_circuit_test.h5")
   N = length(Ψ)     # Number of qubits
   χ = maxlinkdim(Ψ) # Bond dimension of variational MPS
   ψ0 = randomstate(Ψ; χ = χ, σ = 0.1)
@@ -23,7 +23,7 @@ using Test
   @test length(obs.frobenius_distance) == 0
   @test length(obs.negative_loglikelihood) == 3
   
-  data, ϱ = readdata("../examples/data/qst_circuit_noisy_test.h5")
+  data, ϱ = readsamples("../examples/data/qst_circuit_noisy_test.h5")
   N = length(ϱ)     # Number of qubits
   χ = maxlinkdim(ϱ) # Bond dimension of variational LPDO
   ξ = 2             # Kraus dimension of variational LPDO
@@ -40,7 +40,7 @@ using Test
   @test length(obs.frobenius_distance) == 3
   @test length(obs.negative_loglikelihood) == 3
   
-  data, U = readdata("../examples/data/qpt_circuit_test.h5")
+  data, U = readsamples("../examples/data/qpt_circuit_test.h5")
   N = length(U)     # Number of qubits
   χ = maxlinkdim(U) # Bond dimension of variational MPS
   opt = SGD(η = 0.1)
@@ -59,7 +59,7 @@ using Test
   
   # Noisy circuit
   Random.seed!(1234)
-  data, ϱ = readdata("../examples/data/qpt_circuit_noisy_test.h5")
+  data, ϱ = readsamples("../examples/data/qpt_circuit_noisy_test.h5")
   N = length(ϱ)
   χ = 8
   ξ = 2


### PR DESCRIPTION
Change process tomography samples data format to be a matrix of pairs of input and output data instead of two matrices. This unifies the interface between state tomography and process tomography, and makes the reading and writing interface simpler.

I've also change the names of `savedata`/`loaddata` to `writesamples`/`readsamples`, since I find the term "data" to be a bit generic (even if it comes from experimental measurements, I think it can still be considered a "sample" from the quantum system in the experiment).