### PR TITLE
New tomography observer interface

### DIFF
--- a/src/circuits/getsamples.jl
+++ b/src/circuits/getsamples.jl
@@ -117,7 +117,7 @@ function getsamples!(M::Union{MPS,MPO};
   orthogonalize!(M,1)
   measurement = sample(M)
   measurement .-= 1
-  if !isnothing(p1given0) | !isnothing(p0given1)
+  if !isnothing(p1given0) || !isnothing(p0given1)
     p1given0 = (isnothing(p1given0) ? 0.0 : p1given0)
     p0given1 = (isnothing(p0given1) ? 0.0 : p0given1)
     readouterror!(measurement,p1given0,p0given1)
@@ -232,6 +232,7 @@ function getsamples(M0::Union{MPS,MPO},
                     prep::Array, basis::Array;
                     cutoff::Float64 = 1e-15,
                     maxdim::Int64 = 10000,
+                    readout_errors = nothing,
                     kwargs...)
   # Generate preparation/measurement gates
   prep_gates = preparationgates(prep)
@@ -244,7 +245,7 @@ function getsamples(M0::Union{MPS,MPO},
   # Apply basis rotation
   M_meas = runcircuit(M_out, meas_gates)
   # Measure
-  measurement = getsamples!(M_meas; kwargs...)
+  measurement = getsamples!(M_meas; readout_errors = readout_errors)
   
   return convertdatapoint(measurement, basis)
 end
@@ -365,7 +366,8 @@ function getsamples(N::Int64, gates::Vector{<:Tuple}, nshots::Int64;
         data[n,:] = getsamples(ψ0, gate_tensors, preps[n,:], bases[n,:];
                                noise = noise, cutoff = cutoff,
                                build_process = false, # TODO: is this needed?
-                               maxdim = maxdim, readout_errors = readout_errors,
+                               maxdim = maxdim,
+                               readout_errors = readout_errors,
                                kwargs...)
       end
       return preps .=> data

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -1,7 +1,6 @@
 export 
-# quantumgates.jl
-  # Methods
-  gate,
+# ITensors
+  maxlinkdim,
 
 # circuits/circuits.jl
   appendlayer!,
@@ -9,13 +8,14 @@ export
   qft,
   randomcircuit,
 
-# lpdo.jl
-  LPDO,
-  logtr,
-  tr,
+# circuits/gates.jl
+  # Methods
+  gate,
 
-# choi.jl,
-  Choi,
+# circuits/getsamples.jl
+  # Methods
+  getsamples,
+  randombases,
 
 # circuits/runcircuit.jl
   # Methods
@@ -25,17 +25,20 @@ export
   buildcircuit,
   runcircuit,
 
-# datagen.jl
-  # Methods
-  getsamples,
-  randombases,
+# lpdo.jl
+  LPDO,
+  logtr,
+  tr,
+
+# choi.jl,
+  Choi,
 
 # randomstates,jl
   # Methods
   randomstate,
   randomprocess,
 
-# quantumtomography,jl
+# tomography,jl
   # Methods
   normalize!,
   tomography,
@@ -46,21 +49,17 @@ export
   fidelity_bound,
   frobenius_distance,
 
-# optimizers/
+# optimizers.jl
   Optimizer,
   SGD,
   AdaGrad,
   AdaDelta,
   Adam,
   AdaMax,
-  # Methods
-  resetoptimizer!,
 
 # observer.jl
   TomographyObserver,
-  # Methods
-  writeobserver,
-  
+
 # utils.jl
   # Methods
   writesamples,

--- a/src/observer.jl
+++ b/src/observer.jl
@@ -13,7 +13,9 @@ struct TomographyObserver <: AbstractObserver
   end
 end
 
-negative_loglikelihood(obs::TomographyObserver) = obs.negative_loglikelihood
+negative_loglikelihood(obs::TomographyObserver) =
+  obs.negative_loglikelihood
+
 fidelity(o::TomographyObserver) = o.fidelity
 fidelity_bound(o::TomographyObserver) = o.fidelity_bound
 frobenius_distance(o::TomographyObserver) = o.frobenius_distance
@@ -40,15 +42,16 @@ function measure!(obs::TomographyObserver;
   end
 end
 
-function saveobserver(obs::TomographyObserver,fout::String; M=nothing)
+function saveobserver(obs::TomographyObserver,
+                      fout::String; M=nothing)
   h5rewrite(fout,"w") do file
-    write(file,"nll",obs.negative_loglikelihood)
-    write(file,"fidelity",obs.fidelity)
-    write(file,"frobenius_distance",obs.frobenius_distance)
-    write(file,"fidelity_bound",obs.fidelity_bound)
-    write(file,"nll",obs.negative_loglikelihood)
+    write(file,"nll", obs.negative_loglikelihood)
+    write(file,"fidelity", obs.fidelity)
+    write(file,"frobenius_distance", obs.frobenius_distance)
+    write(file,"fidelity_bound", obs.fidelity_bound)
+    write(file,"nll", obs.negative_loglikelihood)
     if !isnothing(M)
-      write(file,"model",M)
+      write(file, "model", M)
     end
   end
 end

--- a/src/optimizers.jl
+++ b/src/optimizers.jl
@@ -186,14 +186,10 @@ end
 
 update!(ψ::MPS,∇::Array,opt::AdaDelta; kwargs...) = update!(LPDO(ψ),∇,opt; kwargs...)
 
-
 function resetoptimizer!(opt::AdaDelta)
   empty!(opt.∇²)
   empty!(opt.Δθ²)
 end
-
-
-
 
 struct Adam <: Optimizer 
   η::Float64

--- a/test/circuitops.jl
+++ b/test/circuitops.jl
@@ -276,24 +276,24 @@ end
   ϕ = 2π * rand()
   psi = qubits(1)
   PastaQ.applygate!(psi,"Rz",1,ϕ=ϕ)
-  @test array(psi[1]) ≈ [exp(-im*ϕ/2.), 0.]
+  @test array(psi[1]) ≈ [1.0, 0.0]
   psi = qubits(1)
   PastaQ.applygate!(psi,"X",1)
   PastaQ.applygate!(psi,"Rz",1,ϕ=ϕ)
-  @test array(psi[1]) ≈ [0.,exp(im*ϕ/2.)]
+  @test array(psi[1]) ≈ [0.0, exp(im*ϕ)]
   
   ϕ = 2π * rand()
   psi = qubits(1)
   gate_data = ("Rz",1,(ϕ=ϕ,))
   g = gate(psi,gate_data)
   PastaQ.applygate!(psi,g)
-  @test array(psi[1]) ≈ [exp(-im*ϕ/2.), 0.]
+  @test array(psi[1]) ≈ [1.0, 0.0]
   psi = qubits(1)
   PastaQ.applygate!(psi,"X",1)
   gate_data = ("Rz",1,(ϕ=ϕ,))
   g = gate(psi,gate_data)
   PastaQ.applygate!(psi,g)
-  @test array(psi[1]) ≈ [0.,exp(im*ϕ/2.)]
+  @test array(psi[1]) ≈ [0.0, exp(im*ϕ)]
 end
 
 @testset "apply gate: Rn" begin

--- a/test/observer.jl
+++ b/test/observer.jl
@@ -11,12 +11,13 @@ using Test
   χ = maxlinkdim(Ψ) # Bond dimension of variational MPS
   ψ0 = randomstate(Ψ; χ = χ, σ = 0.1)
   opt = SGD(η = 0.01)
-  ψ, obs = tomography(data, ψ0;
-                      optimizer = opt,
-                      batchsize = 10,
-                      epochs = 3,
-                      target = Ψ,
-                      record = true);
+  obs = TomographyObserver()
+  ψ = tomography(data, ψ0;
+                 optimizer = opt,
+                 batchsize = 10,
+                 epochs = 3,
+                 target = Ψ,
+                 observer! = obs)
   
   @test length(obs.fidelity) == 3
   @test length(obs.fidelity_bound) == 0
@@ -29,12 +30,14 @@ using Test
   ξ = 2             # Kraus dimension of variational LPDO
   ρ0 = randomstate(ϱ; mixed = true, χ = χ, ξ = ξ, σ = 0.1)
   opt = SGD(η = 0.01)
-  ρ, obs = tomography(data,ρ0;
-                      optimizer = opt,
-                      batchsize = 10,
-                      epochs = 3,
-                      target = ϱ,
-                      record = true);
+  obs = TomographyObserver()
+  ρ = tomography(data, ρ0;
+                 optimizer = opt,
+                 batchsize = 10,
+                 epochs = 3,
+                 target = ϱ,
+                 observer! = obs)
+
   @test length(obs.fidelity) == 3
   @test length(obs.fidelity_bound) == 3
   @test length(obs.frobenius_distance) == 3
@@ -45,12 +48,13 @@ using Test
   χ = maxlinkdim(U) # Bond dimension of variational MPS
   opt = SGD(η = 0.1)
   V0 = randomprocess(U; mixed = false, χ = χ)
-  V, obs = tomography(data, V0;
-                      optimizer = opt,
-                      batchsize = 10,
-                      epochs = 3,
-                      target = U,
-                      record = true)
+  obs = TomographyObserver()
+  V = tomography(data, V0;
+                 optimizer = opt,
+                 batchsize = 10,
+                 epochs = 3,
+                 target = U,
+                 observer! = obs)
 
   @test length(obs.fidelity) == 3
   @test length(obs.fidelity_bound) == 0
@@ -65,13 +69,15 @@ using Test
   ξ = 2
   Λ0 = randomprocess(ϱ; mixed = true, χ = χ, ξ = ξ, σ = 0.1)
   opt = SGD(η = 0.1)
-  Λ, obs = tomography(data, Λ0;
-                      optimizer = opt,
-                      mixed = true,
-                      batchsize = 10,
-                      epochs = 3,
-                      target = ϱ,
-                      record = true);
+  obs = TomographyObserver()
+  Λ = tomography(data, Λ0;
+                 optimizer = opt,
+                 mixed = true,
+                 batchsize = 10,
+                 epochs = 3,
+                 target = ϱ,
+                 observer! = obs)
+
   @test length(obs.fidelity) == 3
   @test length(obs.fidelity_bound) == 3
   @test length(obs.frobenius_distance) == 3


### PR DESCRIPTION
This implements and closes #112. Basically the `record` keyword argument is replaced by the `observer!` keyword argument, and an observer that has been created before calling the function is passed to that keyword argument.