### PR TITLE
Remove prep/meas gate types

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ gates = randomcircuit(N, depth) # Build gates
 data, ψ = getsamples(N, gates, nshots)
 
 #  Note: the above is equivalent to:
-# > bases = randombases(N, nshots; localbasis = ["X","Y","Z"])
+# > bases = randombases(N, nshots; local_basis = ["X","Y","Z"])
 # > ψ = runcircuit(N, gates)
 # > data = getsamples(ψ, bases)
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -168,7 +168,7 @@ gates = randomcircuit(N, depth) # Build gates
 data, ψ = getsamples(N, gates, nshots)
 
 #  Note: the above is equivalent to:
-# > bases = randombases(N, nshots; localbasis = ["X","Y","Z"])
+# > bases = randombases(N, nshots; local_basis = ["X","Y","Z"])
 # > ψ = runcircuit(N, gates)
 # > data = getsamples(ψ, bases)
 

--- a/examples/1_quantumgates.jl
+++ b/examples/1_quantumgates.jl
@@ -14,7 +14,7 @@ Random.seed!(1234)
 
 # Show samples from P(x) = |⟨x|ψ⟩|²
 println("Sample from |ψ⟩ = X₂|0,0,0⟩:")
-display(getsamples(ψ, 3))
+display(getsamples(ψ, 3; local_basis = nothing))
 println()
 
 # Custom gates
@@ -38,6 +38,6 @@ resetqubits!(ψ)
 # Show samples from P(x) = |⟨x|ψ⟩|²
 println("Sample from |ψ⟩ = iX₁|0,0,0⟩:")
 ψ = applygate(ψ, "iX", 1)
-display(getsamples(ψ, 3))
+display(getsamples(ψ, 3; local_basis = nothing))
 println()
 

--- a/examples/3_qft_circuit.jl
+++ b/examples/3_qft_circuit.jl
@@ -27,7 +27,7 @@ starting_state = [number_bin[n] == 1 ? ("X", n) : ("I", n) for n in 1:N]
 
 ψ0 = runcircuit(ψ0, starting_state)
 
-samples = getsamples(ψ0, 5)
+samples = getsamples(ψ0, 5; local_basis = nothing)
 println("Sample from the initial state |$(number_bin_st)⟩:")
 display(samples)
 println()
@@ -47,7 +47,7 @@ println()
 ψ = runcircuit(ψ0, gates)
 
 println("Sample from QFT|$(number_bin_st)⟩:")
-samples = getsamples(ψ, 5)
+samples = getsamples(ψ, 5; local_basis = nothing)
 display(samples)
 println()
 
@@ -61,6 +61,6 @@ gates⁻¹ = qft(N; inverse = true)
 ψ = runcircuit(ψ, gates⁻¹)
 
 println("Sample from QFT⁻¹QFT|$(number_bin_st)⟩:")
-samples = getsamples(ψ, 5)
+samples = getsamples(ψ, 5; local_basis = nothing)
 display(samples)
 

--- a/examples/5_datageneration.jl
+++ b/examples/5_datageneration.jl
@@ -16,7 +16,8 @@ gates = randomcircuit(N,depth)
 # is `["X","Y","Z"]`.
 # a) Unitary circuit
 println("Generate samples from random projective measurements of the state U|0,0,…>:")
-data, ψ = getsamples(N, gates, nshots; localbasis = ["X","Y","Z"])
+data, ψ = getsamples(N, gates, nshots;
+                     localbasis = ["X","Y","Z"])
 # Returns output state as MPS
 @show maxlinkdim(ψ)
 display(data)
@@ -29,7 +30,8 @@ println()
 
 # b) Noisy circuit
 println("Generate samples from random projective measurements of the state ρ = ε(|0,0,…⟩⟨0,0,…|) generated from noisy gate evolution:")
-data, ρ = getsamples(N, gates, nshots; localbasis = ["X","Y","Z"], 
+data, ρ = getsamples(N, gates, nshots;
+                     localbasis = ["X","Y","Z"], 
                      noise = ("amplitude_damping", (γ = 0.01,)))
 writesamples(data, ρ, "data/qst_circuit_noisy.h5")
 # Return the mixed density operator as MPO

--- a/examples/5_datageneration.jl
+++ b/examples/5_datageneration.jl
@@ -12,26 +12,24 @@ gates = randomcircuit(N,depth)
 
 # 1. Generation of measurement data on the quantum states
 # at the output of a circuit. Each data-point is a projetive
-# measurement in an arbitrary local basis.Default local basis 
+# measurement in an arbitrary local basis. The default local basis 
 # is `["X","Y","Z"]`.
 # a) Unitary circuit
 println("Generate samples from random projective measurements of the state U|0,0,…>:")
-data, ψ = getsamples(N, gates, nshots;
-                     localbasis = ["X","Y","Z"])
+data, ψ = getsamples(N, gates, nshots)
 # Returns output state as MPS
 @show maxlinkdim(ψ)
 display(data)
 println()
 
 # Note: the above is equivalent to:
-#> bases = randombases(N,nshots,localbasis=["X","Y","Z"])
+#> bases = randombases(N,nshots)
 #> ψ = runcircuit(N,gates)
 #> data = getsamples(ψ,nshots,bases)
 
 # b) Noisy circuit
 println("Generate samples from random projective measurements of the state ρ = ε(|0,0,…⟩⟨0,0,…|) generated from noisy gate evolution:")
 data, ρ = getsamples(N, gates, nshots;
-                     localbasis = ["X","Y","Z"], 
                      noise = ("amplitude_damping", (γ = 0.01,)))
 writesamples(data, ρ, "data/qst_circuit_noisy.h5")
 # Return the mixed density operator as MPO

--- a/examples/6_qst_circuit.jl
+++ b/examples/6_qst_circuit.jl
@@ -11,8 +11,8 @@ Random.seed!(1234)
 N = 4
 depth = 4
 nshots = 10_000
-gates = randomcircuit(N,depth)
-data, ψ = getsamples(N, gates, nshots; localbasis = ["X","Y","Z"])
+gates = randomcircuit(N, depth)
+data, ψ = getsamples(N, gates, nshots)
 writesamples(data, ψ, "data/qst_circuit.h5")
 
 # Load target state and measurement data
@@ -23,7 +23,7 @@ N = length(Ψ)     # Number of qubits
 χ = maxlinkdim(Ψ) # Bond dimension of variational MPS
 
 # Initialize the variational MPS
-ψ0 = randomstate(Ψ; χ=χ)
+ψ0 = randomstate(Ψ; χ = χ)
 
 # Initialize stochastic gradient descent optimizer
 opt = SGD(η = 0.01)
@@ -45,7 +45,7 @@ println()
 # as the output of a noisy quantum circuit
 
 # Generate sample data
-data, ρ = getsamples(N, gates, nshots; localbasis = ["X","Y","Z"],
+data, ρ = getsamples(N, gates, nshots;
                      noise = ("amplitude_damping", (γ = 0.01,)))
 writesamples(data, ρ, "data/qst_circuit_noisy.h5")
 

--- a/examples/6_qst_circuit.jl
+++ b/examples/6_qst_circuit.jl
@@ -31,7 +31,7 @@ opt = SGD(η = 0.01)
 # Run quantum state tomography, where a variational MPS `|ψ(θ)⟩`
 # is optimized to mimimize the cross entropy between the data and 
 # the tensor-network distribution `P(x) = |⟨x|ψ(θ)⟩|²`.
-println("Running tomography on to learn a pure state ψ:")
+println("Running tomography to learn a pure state ψ:")
 ψ = tomography(data, ψ0;
                optimizer = opt,
                batchsize = 1000,
@@ -65,7 +65,7 @@ opt = SGD(η = 0.1)
 # Run quantum state tomography, where a variational LPDO `ρ(θ)`
 # is optimized to mimimize the cross entropy between the data and 
 # the tensor-network distribution `P(x) = ⟨x|ρ(θ)|x⟩`.
-println("Running tomography on to learn a mixed state ρ:")
+println("Running tomography to learn a mixed state ρ:")
 ρ = tomography(data, ρ0;
                optimizer = opt,
                batchsize = 1000,

--- a/src/circuits/gates.jl
+++ b/src/circuits/gates.jl
@@ -13,40 +13,40 @@ end
 # State-like gates, used to define product input states
 #
 
-initstate(::StateName"X+") =
+inputstate(::StateName"X+") =
   [1/sqrt(2)
    1/sqrt(2)]
 
-initstate(::StateName"X-") =
+inputstate(::StateName"X-") =
   [ 1/sqrt(2)
    -1/sqrt(2)]
 
-initstate(::StateName"Y+") =
+inputstate(::StateName"Y+") =
   [  1/sqrt(2)
    im/sqrt(2)]
 
-initstate(::StateName"Y-") =
+inputstate(::StateName"Y-") =
   [  1/sqrt(2)
    -im/sqrt(2)]
 
-initstate(::StateName"Z+") =
+inputstate(::StateName"Z+") =
   [1
    0]
 
-initstate(::StateName"0") =
-  initstate("Z+")
+inputstate(::StateName"0") =
+  inputstate("Z+")
 
-initstate(::StateName"Z-") =
+inputstate(::StateName"Z-") =
   [0
    1]
 
-initstate(::StateName"1") =
-  initstate("Z-")
+inputstate(::StateName"1") =
+  inputstate("Z-")
 
-initstate(sn::String; kwargs...) = initstate(StateName(sn); kwargs...)
+inputstate(sn::String; kwargs...) = inputstate(StateName(sn); kwargs...)
 
-initstate(sn::String, i::Index; kwargs...) =
-  itensor(initstate(sn; kwargs...), i)
+inputstate(sn::String, i::Index; kwargs...) =
+  itensor(inputstate(sn; kwargs...), i)
 
 #
 # 1-qubit gates

--- a/src/circuits/gates.jl
+++ b/src/circuits/gates.jl
@@ -9,25 +9,6 @@ macro GateName_str(s)
   GateName{ITensors.SmallString(s)}
 end
 
-##################################################################
-# TODO: DELETE
-#
-#
-## Measurement rotation: |sX> -> |sZ>
-#gate(::GateName"basisX") =
-#  gate("H")
-#
-## Measurement rotation: |sY> -> |sZ>
-#gate(::GateName"basisY") =
-#  [1/sqrt(2) -im/sqrt(2)
-#   1/sqrt(2)  im/sqrt(2)]
-#
-## Measurement rotation: |sZ> -> |sZ>
-#gate(::GateName"basisZ") =
-#  gate("I")
-#
-##################################################################
-
 #
 # State-like gates, used to define product input states
 #

--- a/src/circuits/gates.jl
+++ b/src/circuits/gates.jl
@@ -12,39 +12,6 @@ end
 
 ########################################################################
 # TODO: DELETE
-# Measurement projections onto a state.
-# State projector names must start with "state".
-#
-
-#gate(::GateName"X+") =
-#  [1/sqrt(2)
-#   1/sqrt(2)]
-#
-#gate(::GateName"X-") =
-#  [ 1/sqrt(2)
-#   -1/sqrt(2)]
-#
-#gate(::GateName"Y+") =
-#  [  1/sqrt(2)
-#   im/sqrt(2)]
-#
-#gate(::GateName"Y-") =
-#  [  1/sqrt(2)
-#   -im/sqrt(2)]
-#
-#gate(::GateName"Z+") =
-#  [1
-#   0]
-#
-#gate(::GateName"0") =
-#  gate("Z+")
-#
-#gate(::GateName"Z-") =
-#  [0
-#   1]
-#
-#gate(::GateName"1") =
-#  gate("Z-")
 
 #
 # Measurement gates
@@ -66,69 +33,38 @@ gate(::GateName"measZ") =
 ########################################################################
 
 #
-# Qubit site type
+# State-like gates, used to define product input states
 #
 
-import ITensors: space
-
-space(::SiteType"Qubit") = 2
-
-#
-# Single qubit states used for making product states
-#
-
-import ITensors: state
-
-state(::SiteType"Qubit", ::StateName"0") = 1
-
-state(::SiteType"Qubit", ::StateName"1") = 2
-
-state(::StateName"X+") =
+gate(::GateName"X+") =
   [1/sqrt(2)
    1/sqrt(2)]
 
-state(::StateName"X-") =
+gate(::GateName"X-") =
   [ 1/sqrt(2)
    -1/sqrt(2)]
 
-state(::StateName"Y+") =
-  [ 1/sqrt(2)
+gate(::GateName"Y+") =
+  [  1/sqrt(2)
    im/sqrt(2)]
 
-state(::StateName"Y-") =
+gate(::GateName"Y-") =
   [  1/sqrt(2)
    -im/sqrt(2)]
 
-state(::StateName"Z+") =
+gate(::GateName"Z+") =
   [1
    0]
 
-state(::StateName"0") =
-  state("Z+")
+gate(::GateName"0") =
+  gate("Z+")
 
-state(::StateName"Z-") =
+gate(::GateName"Z-") =
   [0
    1]
 
-state(::StateName"1") =
-  state("Z-")
-
-# Version that accepts a dimension for the gate,
-# for qudits or other more general states
-state(sn::StateName, N::Int; kwargs...) =
-  state(sn; kwargs...)
-
-function state(sn::StateName, s::Index; kwargs...)
-  st = state(sn, dim(s); kwargs...)
-  return itensor(st, s)
-end
-
-function state(sn::String, s::Index; kwargs...)
-  if length(sn) > 8
-    sn = sn[1:8]
-  end
-  return state(StateName(sn), s; kwargs...)
-end
+gate(::GateName"1") =
+  gate("Z-")
 
 #
 # 1-qubit gates
@@ -432,6 +368,20 @@ gate(::GateName"noiseAD"; kwargs...) =
 
 gate(::GateName"noisePD"; kwargs...) =
   gate("PD";kwargs...)
+
+#
+# Qubit site type
+#
+
+import ITensors: space
+
+space(::SiteType"Qubit") = 2
+
+import ITensors: state
+
+state(::SiteType"Qubit", ::StateName"0") = 1
+
+state(::SiteType"Qubit", ::StateName"1") = 2
 
 #
 # Basis definitions (eigenbases of measurement gates)

--- a/src/circuits/gates.jl
+++ b/src/circuits/gates.jl
@@ -13,6 +13,8 @@ end
 # State-like gates, used to define product input states
 #
 
+# TODO: add an arbitrary state specified by angles
+
 inputstate(::StateName"X+") =
   [1/sqrt(2)
    1/sqrt(2)]
@@ -367,7 +369,6 @@ state(::SiteType"Qubit", ::StateName"1") = 2
 
 #
 # Basis definitions (eigenbases of measurement gates)
-# TODO: remove these in favor of a generic solution
 #
 
 function phase(v::AbstractVector{ElT}) where {ElT <: Number}

--- a/src/circuits/gates.jl
+++ b/src/circuits/gates.jl
@@ -1,4 +1,8 @@
 #
+# TODO: delete meas gates
+#
+
+#
 # Qubit site type
 #
 
@@ -322,24 +326,6 @@ function gate(::GateName"randU", N::Int = 2;
 end
 
 #
-# Measurement gates
-#
-
-# Measurement rotation: |sX> -> |sZ>
-gate(::GateName"measX") =
-  gate("H")
-
-# Measurement rotation: |sY> -> |sZ>
-gate(::GateName"measY") =
-  [1/sqrt(2) -im/sqrt(2)
-   1/sqrt(2)  im/sqrt(2)]
-
-# Measurement rotation: |sZ> -> |sZ>
-gate(::GateName"measZ") =
-  gate("I")
-
-
-#
 # Noise model gate definitions
 #
 
@@ -404,14 +390,17 @@ gate(::GateName"noisePD"; kwargs...) =
 gate(::GateName{gn}; kwargs...) where {gn} =
   error("A gate with the name \"$gn\" has not been implemented yet. You can define it by overloading `gate(::GateName\"$gn\") = [...]`.")
 
-gate(s::String) = gate(GateName(s))
+# This uses Base.invokelatest since certain gate overloads
+# are made on the fly with @eval
+gate(s::String) = Base.invokelatest(gate, GateName(s))
 
 # Version that accepts a dimension for the gate,
 # for n-qubit gates
 gate(gn::GateName, N::Int; kwargs...) =
   gate(gn; kwargs...)
 
-function gate(gn::GateName, s::Index...; kwargs...)
+function gate(gn::GateName, s1::Index, ss::Index...; kwargs...)
+  s = tuple(s1, ss...)
   rs = reverse(s)
   g = gate(gn, dim(s); kwargs...) 
   if ndims(g) == 1
@@ -447,4 +436,22 @@ function ITensors.op(gn::GateName,
                      kwargs...)
   return gate(gn, s...; kwargs...)
 end
+
+#
+# Basis definitions (eigenbases of measurement gates)
+# These are kept as a reference
+#
+
+## Measurement rotation: |sX> -> |sZ>
+#gate(::GateName"basisX") =
+#  gate("H")
+#
+## Measurement rotation: |sY> -> |sZ>
+#gate(::GateName"basisY") =
+#  [1/sqrt(2) -im/sqrt(2)
+#   1/sqrt(2)  im/sqrt(2)]
+#
+## Measurement rotation: |sZ> -> |sZ>
+#gate(::GateName"basisZ") =
+#  gate("I")
 

--- a/src/circuits/gates.jl
+++ b/src/circuits/gates.jl
@@ -36,35 +36,40 @@ gate(::GateName"measZ") =
 # State-like gates, used to define product input states
 #
 
-gate(::GateName"X+") =
+initstate(::StateName"X+") =
   [1/sqrt(2)
    1/sqrt(2)]
 
-gate(::GateName"X-") =
+initstate(::StateName"X-") =
   [ 1/sqrt(2)
    -1/sqrt(2)]
 
-gate(::GateName"Y+") =
+initstate(::StateName"Y+") =
   [  1/sqrt(2)
    im/sqrt(2)]
 
-gate(::GateName"Y-") =
+initstate(::StateName"Y-") =
   [  1/sqrt(2)
    -im/sqrt(2)]
 
-gate(::GateName"Z+") =
+initstate(::StateName"Z+") =
   [1
    0]
 
-gate(::GateName"0") =
-  gate("Z+")
+initstate(::StateName"0") =
+  initstate("Z+")
 
-gate(::GateName"Z-") =
+initstate(::StateName"Z-") =
   [0
    1]
 
-gate(::GateName"1") =
-  gate("Z-")
+initstate(::StateName"1") =
+  initstate("Z-")
+
+initstate(sn::String; kwargs...) = initstate(StateName(sn); kwargs...)
+
+initstate(sn::String, i::Index; kwargs...) =
+  itensor(initstate(sn; kwargs...), i)
 
 #
 # 1-qubit gates

--- a/src/circuits/gates.jl
+++ b/src/circuits/gates.jl
@@ -16,35 +16,35 @@ end
 # State projector names must start with "state".
 #
 
-gate(::GateName"X+") =
-  [1/sqrt(2)
-   1/sqrt(2)]
-
-gate(::GateName"X-") =
-  [ 1/sqrt(2)
-   -1/sqrt(2)]
-
-gate(::GateName"Y+") =
-  [  1/sqrt(2)
-   im/sqrt(2)]
-
-gate(::GateName"Y-") =
-  [  1/sqrt(2)
-   -im/sqrt(2)]
-
-gate(::GateName"Z+") =
-  [1
-   0]
-
-gate(::GateName"0") =
-  gate("Z+")
-
-gate(::GateName"Z-") =
-  [0
-   1]
-
-gate(::GateName"1") =
-  gate("Z-")
+#gate(::GateName"X+") =
+#  [1/sqrt(2)
+#   1/sqrt(2)]
+#
+#gate(::GateName"X-") =
+#  [ 1/sqrt(2)
+#   -1/sqrt(2)]
+#
+#gate(::GateName"Y+") =
+#  [  1/sqrt(2)
+#   im/sqrt(2)]
+#
+#gate(::GateName"Y-") =
+#  [  1/sqrt(2)
+#   -im/sqrt(2)]
+#
+#gate(::GateName"Z+") =
+#  [1
+#   0]
+#
+#gate(::GateName"0") =
+#  gate("Z+")
+#
+#gate(::GateName"Z-") =
+#  [0
+#   1]
+#
+#gate(::GateName"1") =
+#  gate("Z-")
 
 #
 # Measurement gates

--- a/src/circuits/gates.jl
+++ b/src/circuits/gates.jl
@@ -37,14 +37,14 @@ gate(::GateName"Z+") =
    0]
 
 gate(::GateName"0") =
-  gate("stateZ+")
+  gate("Z+")
 
 gate(::GateName"Z-") =
   [0
    1]
 
 gate(::GateName"1") =
-  gate("stateZ-")
+  gate("Z-")
 
 #
 # Measurement gates

--- a/src/circuits/getsamples.jl
+++ b/src/circuits/getsamples.jl
@@ -40,14 +40,14 @@ is added to the list.
 
 Example:
   basis = ["X","Z","Z","Y"]
-  -> gate_list = [("measX", 1),
-                  ("measY", 4)]
+  -> gate_list = [("basisX", 1),
+                  ("basisY", 4)]
 """
 function measurementgates(basis::Array)
   gate_list = Tuple[]
   for j in 1:length(basis)
-    if (basis[j]!= "Z")
-      push!(gate_list,("meas$(basis[j])", j))
+    if basis[j] ≠ "Z"
+      push!(gate_list, ("basis$(basis[j])", j, (dag = true,)))
     end
   end
   return gate_list

--- a/src/circuits/getsamples.jl
+++ b/src/circuits/getsamples.jl
@@ -1,7 +1,7 @@
 """
-    randombases(N::Int,nshots::Int;
-                localbasis::Array=["X","Y","Z"],
-                ndistinctbases=nothing)
+    randombases(N::Int, nshots::Int;
+                local_basis = ["X","Y","Z"],
+                ndistinctbases = nothing)
 
 Generate `nshots` measurement bases. By default, each
 local basis is randomly selected between `["X","Y","Z"]`, with
@@ -10,19 +10,19 @@ If `ndistinctbases` is provided, the output consist of `ndistinctbases`
 different measurement basis, each being repeated `nshots÷ndistinctbases`
 times.
 """
-function randombases(N::Int,numshots::Int;
-                     localbasis::Array=["X","Y","Z"],
-                     ndistinctbases=nothing)
+function randombases(N::Int, numshots::Int;
+                     local_basis = ["X","Y","Z"],
+                     ndistinctbases = nothing)
   # One shot per basis
   if isnothing(ndistinctbases)
-    bases = rand(localbasis,numshots,N)
+    bases = rand(local_basis,numshots,N)
   # Some number of shots per basis
   else
     @assert(numshots%ndistinctbases ==0)
     shotsperbasis = numshots÷ndistinctbases
-    bases = repeat(rand(localbasis,1,N),shotsperbasis)
+    bases = repeat(rand(local_basis,1,N),shotsperbasis)
     for n in 1:ndistinctbases-1
-      newbases = repeat(rand(localbasis,1,N),shotsperbasis)
+      newbases = repeat(rand(local_basis,1,N),shotsperbasis)
       bases = vcat(bases,newbases)
     end
   end
@@ -31,7 +31,7 @@ end
 
 
 """
-    measurementgates(basis::Array)
+    measurementgates(basis::Vector)
 
 Given as input a measurement basis, returns the corresponding
 gate data structure. If the basis is `"Z"`, no action is required.
@@ -43,7 +43,7 @@ Example:
   -> gate_list = [("basisX", 1),
                   ("basisY", 4)]
 """
-function measurementgates(basis::Array)
+function measurementgates(basis::Vector)
   gate_list = Tuple[]
   for j in 1:length(basis)
     if basis[j] ≠ "Z"
@@ -55,9 +55,9 @@ end
 
 
 """
-    randompreparations(N::Int,nshots::Int;
-                       local_input_states::Array=["X+","X-","Y+","Y-","Z+","Z-"],
-                       ndistinctstates=nothing)
+    randompreparations(N::Int, nshots::Int;
+                       local_inputstate = ["X+","X-","Y+","Y-","Z+","Z-"],
+                       ndistinctstates = nothing)
 
 Generate `nshots` input states to a quantum circuit. By default, each
 single-qubit state is randomly selected between the 6 eigenstates of
@@ -66,47 +66,23 @@ If `ndistinctstates` is provided, the output consist of `numprep`
 different input states, each being repeated `nshots÷ndistinctstates`
 times.
 """
-function randompreparations(N::Int,nshots::Int;
-                            local_input_states::Array=["X+","X-","Y+","Y-","Z+","Z-"],
-                            ndistinctstates=nothing)
+function randompreparations(N::Int, nshots::Int;
+                            local_inputstate = ["X+","X-","Y+","Y-","Z+","Z-"],
+                            ndistinctstates = nothing)
   # One shot per basis
   if isnothing(ndistinctstates)
-    preparations = rand(local_input_states,nshots,N)
+    preparations = rand(local_inputstate,nshots,N)
   else
     @assert(nshots%ndistinctstates == 0 )
     shotsperstate = nshots÷ndistinctstates
-    preparations = repeat(rand(local_input_states,1,N),shotsperstate)
+    preparations = repeat(rand(local_inputstate,1,N),shotsperstate)
     for n in 1:ndistinctstates-1
-      newstates = repeat(rand(local_input_states,1,N),shotsperstate)
+      newstates = repeat(rand(local_inputstate,1,N),shotsperstate)
       preparations = vcat(preparations,newstates)
     end
   end
   return preparations
 end
-
-
-#"""
-#    preparationgates(prep::Array)
-#
-#Given as input a prepared input state, returns the corresponding
-#gate data structure. If the state is `"Z+"`, no action is required.
-#If not, a quantum gate for state preparation is added to the list.
-#
-#Example:
-#prep = ["X+","Z+","Z+","Y+"]
-#-> gate_list = [("prepX+", 1),
-#                ("prepY+", 4)]
-#"""
-#function preparationgates(prep::Array)
-#  gate_list = Tuple[]
-#  for j in 1:length(prep)
-#    if (prep[j]!= "Z+")
-#      gatename = "prep$(prep[j])"
-#      push!(gate_list, (gatename, j))
-#    end
-#  end
-#  return gate_list
-#end
 
 function getsamples!(M::Union{MPS,MPO};
                      readout_errors = (p1given0 = nothing,
@@ -144,7 +120,7 @@ end
 
 
 """
-    readouterror!(measurement::Array;probs::Array=[0.0,0.0])
+    readouterror!(measurement::Matrix, p1given0, p0given1)
 
 Add readout error to a single measurement
 
@@ -153,7 +129,9 @@ Add readout error to a single measurement
   - `p1given0`: readout error probability 0 -> 1
   - `p0given1`: readout error probability 1 -> 0
 """
-function readouterror!(measurement::Array,p1given0::Float64,p0given1::Float64)
+function readouterror!(measurement::Matrix,
+                       p1given0::Float64,
+                       p0given1::Float64)
 
   for j in 1:size(measurement)[1]
     if measurement[j] == 0
@@ -173,7 +151,7 @@ end
     getsamples(M::Union{MPS,MPO}, bases::Array)
 
 Generate a dataset of `nshots` measurements acccording to a set
-of input `bases`. For a single measurement, tf `Û` is the depth-1 
+of input `bases`. For a single measurement, `Û` is the depth-1 
 local circuit rotating each qubit, the  data-point `σ = (σ₁,σ₂,…)
 is drawn from the probability distribution:
 - P(σ) = |⟨σ|Û|ψ⟩|²   : if M = ψ is MPS
@@ -187,31 +165,39 @@ function getsamples(M0::Union{MPS,MPO}, bases::Array; kwargs...)
     M = runcircuit(M0,meas_gates)
     measurement = getsamples!(M;kwargs...)
     data[n,:] .= bases[n,:] .=> measurement
-    #data[n,:] = convertdatapoint(measurement,bases[n,:])
   end
   return data 
 end
 
 """
-    getsamples(M::Union{MPS,MPO}, nshots::Int; kwargs...)
+    getsamples(M::Union{MPS,MPO}, nshots::Int;
+               local_basis = ["X", "Y", "Z"],
+               ndistinctbases = nothing)
 
-Perform a projective measurement of a wavefunction 
-`|ψ⟩` or density operator `ρ`. The measurement consist of
+Perform `nshots` projective measurements of a wavefunction 
+`|ψ⟩` or density operator `ρ`. The measurement consists of
 a binary vector `σ = (σ₁,σ₂,…)`, drawn from the probabilty
 distribution:
-- P(σ) = |⟨σ|ψ⟩|² : if `M = ψ is MPS`
-- P(σ) = ⟨σ|ρ|σ⟩  : if `M = ρ is MPO`
+- P(σ) = |⟨σ|Û|ψ⟩|² : if `M = ψ is MPS`
+- P(σ) = ⟨σ|Û ρ Û†|σ⟩  : if `M = ρ is MPO`
+
+For a single measurement, `Û` is the depth-1
+local circuit rotating each qubit, where the rotations are determined by
+randomly choosing from the bases specified by `local_basis`
+keyword argument (i.e. if `"X"` is chosen out of `["X", "Y", "Z"]`,
+the rotation is the eigenbasis of `"X"`).
 """
 function getsamples(M::Union{MPS,MPO}, nshots::Int64;
-                    localbasis = nothing, ndistinctbases = nothing,
-                    readout_errors = (p1given0 = nothing, p0given1 = nothing))
-  if isnothing(localbasis)
+                    local_basis = ["X", "Y", "Z"],
+                    ndistinctbases = nothing,
+                    readout_errors = (p1given0 = nothing,
+                                      p0given1 = nothing))
+  if isnothing(local_basis)
     data = getsamples!(copy(M), nshots; readout_errors = readout_errors)
   else
     bases = randombases(length(M), nshots;
-                        localbasis = localbasis,
+                        local_basis = local_basis,
                         ndistinctbases = ndistinctbases)
-
     data = getsamples(M, bases; readout_errors = readout_errors)
   end
   return data
@@ -320,8 +306,8 @@ end
                noise = nothing,
                process::Bool = false,              
                build_process::Bool = false,
-               localbasis::Array = ["X","Y","Z"],                   
-               local_input_states::Array = ["X+","X-","Y+","Y-","Z+","Z-"],
+               local_basis::Array = ["X","Y","Z"],                   
+               local_inputstate::Array = ["X+","X-","Y+","Y-","Z+","Z-"],
                ndistinctbases = nothing,
                ndistinctstates = nothing,
                cutoff::Float64 = 1e-15,
@@ -336,15 +322,15 @@ quantum channel corresponding to a set of quantum `gates` and a `noise` model.
   - `noise`: apply a noise model after each quantum gate in the circuit
   - `process`: if false, generate data for state tomography, where the state is defined by the gates applied to the state `|0,0,...,⟩`. If true, generate data for process tomography.
   - `build_process`: if true, generate data by building the full unitary circuit or Choi matrix, and then sampling from that unitary circuit or Choi matrix (as opposed to running the circuit many times on different initial states). It is only used if `process = true`.
-  - `local_input_states`: a set of input states (e.g. `["X+","X-","Y+","Y-","Z+","Z-"]`) which are chosen randomly to genarate input states.
-  - `localbasis`: the local bases used (e.g. `["X","Y","Z"]) which are chosen randomly to perform measurements in a random basis.
+  - `local_inputstate`: a set of input states (e.g. `["X+","X-","Y+","Y-","Z+","Z-"]`) which are sampled randomly to generate input states.
+  - `local_basis`: the local bases (e.g. `["X","Y","Z"]) which are sampled randomly to perform measurements in a random basis.
 """
 function getsamples(N::Int64, gates::Vector{<:Tuple}, nshots::Int64;
                     noise = nothing,
                     build_process::Bool = true,
                     process::Bool = false,
-                    localbasis = nothing,
-                    local_input_states::Array = ["X+","X-","Y+","Y-","Z+","Z-"],
+                    local_basis = ["X", "Y", "Z"],
+                    local_inputstate = ["X+","X-","Y+","Y-","Z+","Z-"],
                     ndistinctbases = nothing,
                     ndistinctstates = nothing,
                     cutoff::Float64 = 1e-15,
@@ -360,20 +346,20 @@ function getsamples(N::Int64, gates::Vector{<:Tuple}, nshots::Int64;
     
     # Generate projective measurements
     data = getsamples(M,nshots; 
-                      localbasis = localbasis, 
+                      local_basis = local_basis, 
                       ndistinctbases = ndistinctbases,
                       readout_errors = readout_errors)
     return data, M
                       
   else
     
-    localbasis = (isnothing(localbasis) ? ["X","Y","Z"] : localbasis)
+    local_basis = (isnothing(local_basis) ? ["X","Y","Z"] : local_basis)
     
     bases = randombases(N, nshots;
-                        localbasis = localbasis,
+                        local_basis = local_basis,
                         ndistinctbases = ndistinctbases)
     
-    preps = randompreparations(N, nshots, local_input_states = local_input_states,
+    preps = randompreparations(N, nshots, local_inputstate = local_inputstate,
                                ndistinctstates = ndistinctstates)
     
     # Generate the unitary MPO / Choi matrix, then sample from it

--- a/src/circuits/getsamples.jl
+++ b/src/circuits/getsamples.jl
@@ -280,14 +280,14 @@ the quantum channel underlying the Choi matrix to `|ϕ⟩`.
 function projectchoi(Λ0::Choi{MPO}, prep::Array)
   Λ = copy(Λ0)
   choi = Λ.M
-  #state = "state" .* copy(prep) 
-  state = prep
+  #st = "state" .* copy(prep) 
+  st = prep
   s = firstsiteinds(choi, tags="Input")
   
   for j in 1:length(choi)
     # No conjugate on the gate (transpose input!)
-    choi[j] = choi[j] * dag(gate(state[j],s[j]))
-    choi[j] = choi[j] * prime(gate(state[j],s[j]))
+    choi[j] = choi[j] * dag(gate(st[j],s[j]))
+    choi[j] = choi[j] * prime(gate(st[j],s[j]))
   end
   return choi
 end
@@ -302,12 +302,12 @@ The resulting MPS describes the quantum state obtained by applying
 the quantum circuit to `|ϕ⟩`.
 """
 function projectunitary(U::MPO,prep::Array)
-  #state = "state" .* copy(prep) 
-  state = prep
+  #st = "state" .* copy(prep) 
+  st = prep
   M = ITensor[]
   s = firstsiteinds(U)
   for j in 1:length(U)
-    push!(M,U[j] * gate(state[j],s[j]))
+    push!(M,U[j] * gate(st[j],s[j]))
   end
   return noprime!(MPS(M))
 end

--- a/src/circuits/getsamples.jl
+++ b/src/circuits/getsamples.jl
@@ -286,8 +286,8 @@ function projectchoi(Λ0::Choi{MPO}, prep::Array)
   
   for j in 1:length(choi)
     # No conjugate on the gate (transpose input!)
-    choi[j] = choi[j] * dag(gate(st[j],s[j]))
-    choi[j] = choi[j] * prime(gate(st[j],s[j]))
+    choi[j] = choi[j] * dag(state(st[j],s[j]))
+    choi[j] = choi[j] * prime(state(st[j],s[j]))
   end
   return choi
 end
@@ -307,7 +307,7 @@ function projectunitary(U::MPO,prep::Array)
   M = ITensor[]
   s = firstsiteinds(U)
   for j in 1:length(U)
-    push!(M,U[j] * gate(st[j],s[j]))
+    push!(M,U[j] * state(st[j],s[j]))
   end
   return noprime!(MPS(M))
 end

--- a/src/circuits/getsamples.jl
+++ b/src/circuits/getsamples.jl
@@ -18,20 +18,42 @@ function randombases(N::Int,numshots::Int;
     bases = rand(localbasis,numshots,N)
   # Some number of shots per basis
   else
-    @assert(numshots%ndistinctbases ==0)
-    shotsperbasis = numshots÷ndistinctbases
-    bases = repeat(rand(localbasis,1,N),shotsperbasis)
+    @assert numshots % ndistinctbases == 0
+    shotsperbasis = numshots ÷ ndistinctbases
+    bases = repeat(rand(localbasis, 1, N), shotsperbasis)
     for n in 1:ndistinctbases-1
-      newbases = repeat(rand(localbasis,1,N),shotsperbasis)
+      newbases = repeat(rand(localbasis, 1, N), shotsperbasis)
       bases = vcat(bases,newbases)
     end
   end
   return bases
 end
 
+function phase(v::AbstractVector{ElT}) where {ElT <: Number}
+  for x in v
+    absx = abs(x)
+    if absx > 1e-3
+      return x / abs(x)
+    end
+  end
+  return one(ElT)
+end
+
+function eigenbasis(meas::String)
+  _, U = eigen(Hermitian(gate(meas)))
+  # Sort eigenvalues largest to smallest (defaults to smallest to largest)
+  U = reverse(U; dims = 2)
+  # Fix the sign of the eigenvectors
+  for n in 1:size(U, 2)
+    v = @view U[:, n]
+    p = phase(v)
+    v ./= p
+  end
+  return U
+end
 
 """
-    measurementgates(basis::Array)
+    measurementgates(meas::Array)
 
 Given as input a measurement basis, returns the corresponding
 gate data structure. If the basis is `"Z"`, no action is required.
@@ -39,16 +61,24 @@ If not, a quantum gate corresponding to the given basis rotation
 is added to the list.
 
 Example:
-  basis = ["X","Z","Z","Y"]
-  -> gate_list = [("measX", 1),
-                  ("measY", 4)]
+  meas = ["X","Z","Z","Y"]
+  -> gate_list = [("basisX", 1),
+                  ("basisZ", 2),
+                  ("basesZ", 3),
+                  ("basisY", 4)]
 """
-function measurementgates(basis::Array)
+function measurementgates(meas::Array)
+  basis = "basis" .* meas
+  # Define the basis if it doesn't exist
+  for j in 1:length(meas)
+    GN = GateName{ITensors.SmallString(basis[j])}
+    hasmethod(gate, Tuple{GN}) && continue
+    U = copy(eigenbasis(meas[j])')
+    @eval gate(::$GN) = $U
+  end
   gate_list = Tuple[]
-  for j in 1:length(basis)
-    if (basis[j]!= "Z")
-      push!(gate_list,("meas$(basis[j])", j))
-    end
+  for j in 1:length(meas)
+    push!(gate_list, (basis[j], j))
   end
   return gate_list
 end
@@ -73,7 +103,7 @@ function randompreparations(N::Int,nshots::Int;
   if isnothing(ndistinctstates)
     preparations = rand(inputstates,nshots,N)
   else
-    @assert(nshots%ndistinctstates == 0 )
+    @assert nshots % ndistinctstates == 0
     shotsperstate = nshots÷ndistinctstates
     preparations = repeat(rand(inputstates,1,N),shotsperstate)
     for n in 1:ndistinctstates-1
@@ -172,6 +202,7 @@ end
 
 """
     getsamples(M::Union{MPS,MPO}, bases::Array)
+
 Generate a dataset of `nshots` measurements acccording to a set
 of input `bases`. For a single measurement, tf `Û` is the depth-1 
 local circuit rotating each qubit, the  data-point `σ = (σ₁,σ₂,…)
@@ -184,8 +215,8 @@ function getsamples(M0::Union{MPS,MPO}, bases::Array; kwargs...)
   data = Matrix{Pair{String, Int}}(undef, size(bases)[1],length(M0))
   for n in 1:size(bases)[1]
     meas_gates = measurementgates(bases[n,:])
-    M = runcircuit(M0,meas_gates)
-    measurement = getsamples!(M;kwargs...)
+    M = runcircuit(M0, meas_gates)
+    measurement = getsamples!(M; kwargs...)
     data[n,:] .= bases[n,:] .=> measurement
     #data[n,:] = convertdatapoint(measurement,bases[n,:])
   end

--- a/src/circuits/getsamples.jl
+++ b/src/circuits/getsamples.jl
@@ -85,29 +85,28 @@ function randompreparations(N::Int,nshots::Int;
 end
 
 
-"""
-    preparationgates(prep::Array)
-
-Given as input a prepared input state, returns the corresponding
-gate data structure. If the state is `"Z+"`, no action is required.
-If not, a quantum gate for state preparation is added to the list.
-
-Example:
-prep = ["X+","Z+","Z+","Y+"]
--> gate_list = [("prepX+", 1),
-                ("prepY+", 4)]
-"""
-function preparationgates(prep::Array)
-  gate_list = Tuple[]
-  for j in 1:length(prep)
-    if (prep[j]!= "Z+")
-      gatename = "prep$(prep[j])"
-      push!(gate_list, (gatename, j))
-    end
-  end
-  return gate_list
-end
-
+#"""
+#    preparationgates(prep::Array)
+#
+#Given as input a prepared input state, returns the corresponding
+#gate data structure. If the state is `"Z+"`, no action is required.
+#If not, a quantum gate for state preparation is added to the list.
+#
+#Example:
+#prep = ["X+","Z+","Z+","Y+"]
+#-> gate_list = [("prepX+", 1),
+#                ("prepY+", 4)]
+#"""
+#function preparationgates(prep::Array)
+#  gate_list = Tuple[]
+#  for j in 1:length(prep)
+#    if (prep[j]!= "Z+")
+#      gatename = "prep$(prep[j])"
+#      push!(gate_list, (gatename, j))
+#    end
+#  end
+#  return gate_list
+#end
 
 function getsamples!(M::Union{MPS,MPO};
                      readout_errors = (p1given0 = nothing,
@@ -251,11 +250,15 @@ function getsamples(hilbert0::Vector{<:Index},
                     readout_errors = nothing,
                     kwargs...)
   # Generate preparation/measurement gates
-  prep_gates = preparationgates(prep)
   meas_gates = measurementgates(basis)
   # Prepare quantum state
-  M0 = qubits(hilbert0)
-  M_in  = runcircuit(M0, prep_gates)
+  M_in = qubits(hilbert0, prep)
+
+  # TODO: delete
+  #M0 = qubits(hilbert0)
+  #prep_gates = preparationgates(prep)
+  #M_in  = runcircuit(M0, prep_gates)
+
   # Apply the quantum channel
   M_out = runcircuit(M_in, gate_tensors,
                      cutoff = cutoff, maxdim = maxdim) 

--- a/src/circuits/getsamples.jl
+++ b/src/circuits/getsamples.jl
@@ -6,7 +6,7 @@
 Generate `nshots` measurement bases. By default, each
 local basis is randomly selected between `["X","Y","Z"]`, with
 `"Z"` being the default basis where the quantum state is written.
-If `numbases` is provided, the output consist of `ndistinctbases`
+If `ndistinctbases` is provided, the output consist of `ndistinctbases`
 different measurement basis, each being repeated `nshots÷ndistinctbases`
 times.
 """
@@ -56,7 +56,7 @@ end
 
 """
     randompreparations(N::Int,nshots::Int;
-                       inputstates::Array=["X+","X-","Y+","Y-","Z+","Z-"],
+                       local_input_states::Array=["X+","X-","Y+","Y-","Z+","Z-"],
                        ndistinctstates=nothing)
 
 Generate `nshots` input states to a quantum circuit. By default, each
@@ -67,17 +67,17 @@ different input states, each being repeated `nshots÷ndistinctstates`
 times.
 """
 function randompreparations(N::Int,nshots::Int;
-                            inputstates::Array=["X+","X-","Y+","Y-","Z+","Z-"],
+                            local_input_states::Array=["X+","X-","Y+","Y-","Z+","Z-"],
                             ndistinctstates=nothing)
   # One shot per basis
   if isnothing(ndistinctstates)
-    preparations = rand(inputstates,nshots,N)
+    preparations = rand(local_input_states,nshots,N)
   else
     @assert(nshots%ndistinctstates == 0 )
     shotsperstate = nshots÷ndistinctstates
-    preparations = repeat(rand(inputstates,1,N),shotsperstate)
+    preparations = repeat(rand(local_input_states,1,N),shotsperstate)
     for n in 1:ndistinctstates-1
-      newstates = repeat(rand(inputstates,1,N),shotsperstate)
+      newstates = repeat(rand(local_input_states,1,N),shotsperstate)
       preparations = vcat(preparations,newstates)
     end
   end
@@ -321,7 +321,7 @@ end
                process::Bool = false,              
                build_process::Bool = false,
                localbasis::Array = ["X","Y","Z"],                   
-               inputstates::Array = ["X+","X-","Y+","Y-","Z+","Z-"],
+               local_input_states::Array = ["X+","X-","Y+","Y-","Z+","Z-"],
                ndistinctbases = nothing,
                ndistinctstates = nothing,
                cutoff::Float64 = 1e-15,
@@ -336,15 +336,15 @@ quantum channel corresponding to a set of quantum `gates` and a `noise` model.
   - `noise`: apply a noise model after each quantum gate in the circuit
   - `process`: if false, generate data for state tomography, where the state is defined by the gates applied to the state `|0,0,...,⟩`. If true, generate data for process tomography.
   - `build_process`: if true, generate data by building the full unitary circuit or Choi matrix, and then sampling from that unitary circuit or Choi matrix (as opposed to running the circuit many times on different initial states). It is only used if `process = true`.
-  - `inputstates`: a set of input states (e.g. `["X+","X-","Y+","Y-","Z+","Z-"]`)   
-  - `localbasis`: set of basis used (e.g. `["X","Y","Z"])
+  - `local_input_states`: a set of input states (e.g. `["X+","X-","Y+","Y-","Z+","Z-"]`) which are chosen randomly to genarate input states.
+  - `localbasis`: the local bases used (e.g. `["X","Y","Z"]) which are chosen randomly to perform measurements in a random basis.
 """
 function getsamples(N::Int64, gates::Vector{<:Tuple}, nshots::Int64;
                     noise = nothing,
                     build_process::Bool = true,
                     process::Bool = false,
                     localbasis = nothing,
-                    inputstates::Array = ["X+","X-","Y+","Y-","Z+","Z-"],
+                    local_input_states::Array = ["X+","X-","Y+","Y-","Z+","Z-"],
                     ndistinctbases = nothing,
                     ndistinctstates = nothing,
                     cutoff::Float64 = 1e-15,
@@ -373,7 +373,7 @@ function getsamples(N::Int64, gates::Vector{<:Tuple}, nshots::Int64;
                         localbasis = localbasis,
                         ndistinctbases = ndistinctbases)
     
-    preps = randompreparations(N, nshots, inputstates = inputstates,
+    preps = randompreparations(N, nshots, local_input_states = local_input_states,
                                ndistinctstates = ndistinctstates)
     
     # Generate the unitary MPO / Choi matrix, then sample from it

--- a/src/circuits/getsamples.jl
+++ b/src/circuits/getsamples.jl
@@ -286,8 +286,8 @@ function projectchoi(Λ0::Choi{MPO}, prep::Array)
   
   for j in 1:length(choi)
     # No conjugate on the gate (transpose input!)
-    choi[j] = choi[j] * dag(gate(st[j],s[j]))
-    choi[j] = choi[j] * prime(gate(st[j],s[j]))
+    choi[j] = choi[j] * dag(initstate(st[j],s[j]))
+    choi[j] = choi[j] * prime(initstate(st[j],s[j]))
   end
   return choi
 end
@@ -307,7 +307,7 @@ function projectunitary(U::MPO,prep::Array)
   M = ITensor[]
   s = firstsiteinds(U)
   for j in 1:length(U)
-    push!(M,U[j] * gate(st[j],s[j]))
+    push!(M,U[j] * initstate(st[j],s[j]))
   end
   return noprime!(MPS(M))
 end

--- a/src/circuits/getsamples.jl
+++ b/src/circuits/getsamples.jl
@@ -277,35 +277,32 @@ made out of single-qubit Pauli eigenstates (e.g. `|ϕ⟩ =|+⟩⊗|0⟩⊗|r⟩�
 The resulting MPO describes the quantum state obtained by applying
 the quantum channel underlying the Choi matrix to `|ϕ⟩`.
 """
-function projectchoi(Λ0::Choi{MPO}, prep::Array)
+function projectchoi(Λ0::Choi{MPO}, st::Array)
   Λ = copy(Λ0)
   choi = Λ.M
-  state = "state" .* copy(prep) 
-  s = firstsiteinds(choi, tags="Input")
-  
+  s = firstsiteinds(choi, tags = "Input")
   for j in 1:length(choi)
     # No conjugate on the gate (transpose input!)
-    choi[j] = choi[j] * dag(gate(state[j],s[j]))
-    choi[j] = choi[j] * prime(gate(state[j],s[j]))
+    choi[j] = choi[j] * dag(state(st[j], s[j]))
+    choi[j] = choi[j] * prime(state(st[j], s[j]))
   end
   return choi
 end
 
 
 """
-    projectunitary(U0::MPO,prep::Array)
+    projectunitary(U0::MPO, state::Array)
 
 Project the unitary circuit (MPO) into a state `prep` 
 made out of single-qubit Pauli eigenstates (e.g. `|ϕ⟩ =|+⟩⊗|0⟩⊗|r⟩⊗…).
 The resulting MPS describes the quantum state obtained by applying
 the quantum circuit to `|ϕ⟩`.
 """
-function projectunitary(U::MPO,prep::Array)
-  state = "state" .* copy(prep) 
+function projectunitary(U::MPO, st::Array)
   M = ITensor[]
   s = firstsiteinds(U)
   for j in 1:length(U)
-    push!(M,U[j] * gate(state[j],s[j]))
+    push!(M, U[j] * state(st[j], s[j]))
   end
   return noprime!(MPS(M))
 end

--- a/src/circuits/getsamples.jl
+++ b/src/circuits/getsamples.jl
@@ -286,8 +286,8 @@ function projectchoi(Λ0::Choi{MPO}, prep::Array)
   
   for j in 1:length(choi)
     # No conjugate on the gate (transpose input!)
-    choi[j] = choi[j] * dag(state(st[j],s[j]))
-    choi[j] = choi[j] * prime(state(st[j],s[j]))
+    choi[j] = choi[j] * dag(gate(st[j],s[j]))
+    choi[j] = choi[j] * prime(gate(st[j],s[j]))
   end
   return choi
 end
@@ -307,7 +307,7 @@ function projectunitary(U::MPO,prep::Array)
   M = ITensor[]
   s = firstsiteinds(U)
   for j in 1:length(U)
-    push!(M,U[j] * state(st[j],s[j]))
+    push!(M,U[j] * gate(st[j],s[j]))
   end
   return noprime!(MPS(M))
 end

--- a/src/circuits/getsamples.jl
+++ b/src/circuits/getsamples.jl
@@ -120,7 +120,7 @@ end
 
 
 """
-    readouterror!(measurement::Matrix, p1given0, p0given1)
+    readouterror!(measurement::Union{Vector, Matrix}, p1given0, p0given1)
 
 Add readout error to a single measurement
 
@@ -129,7 +129,7 @@ Add readout error to a single measurement
   - `p1given0`: readout error probability 0 -> 1
   - `p0given1`: readout error probability 1 -> 0
 """
-function readouterror!(measurement::Matrix,
+function readouterror!(measurement::Union{Vector, Matrix},
                        p1given0::Float64,
                        p0given1::Float64)
 

--- a/src/circuits/getsamples.jl
+++ b/src/circuits/getsamples.jl
@@ -56,7 +56,7 @@ end
 
 """
     randompreparations(N::Int,nshots::Int;
-                       states::Array=["X+","X-","Y+","Y-","Z+","Z-"],
+                       inputstates::Array=["X+","X-","Y+","Y-","Z+","Z-"],
                        ndistinctstates=nothing)
 
 Generate `nshots` input states to a quantum circuit. By default, each
@@ -171,6 +171,7 @@ end
 
 """
     getsamples(M::Union{MPS,MPO}, bases::Array)
+
 Generate a dataset of `nshots` measurements acccording to a set
 of input `bases`. For a single measurement, tf `Û` is the depth-1 
 local circuit rotating each qubit, the  data-point `σ = (σ₁,σ₂,…)
@@ -202,10 +203,8 @@ distribution:
 - P(σ) = ⟨σ|ρ|σ⟩  : if `M = ρ is MPO`
 """
 function getsamples(M::Union{MPS,MPO}, nshots::Int64;
-                    localbasis = nothing,ndistinctbases = nothing,
-                    readout_errors = (p1given0 = nothing, p0given1 = nothing)
-                   )
-  
+                    localbasis = nothing, ndistinctbases = nothing,
+                    readout_errors = (p1given0 = nothing, p0given1 = nothing))
   if isnothing(localbasis)
     data = getsamples!(copy(M), nshots; readout_errors = readout_errors)
   else
@@ -289,8 +288,8 @@ function projectchoi(Λ0::Choi{MPO}, prep::Array)
   
   for j in 1:length(choi)
     # No conjugate on the gate (transpose input!)
-    choi[j] = choi[j] * dag(initstate(st[j],s[j]))
-    choi[j] = choi[j] * prime(initstate(st[j],s[j]))
+    choi[j] = choi[j] * dag(inputstate(st[j],s[j]))
+    choi[j] = choi[j] * prime(inputstate(st[j],s[j]))
   end
   return choi
 end
@@ -310,7 +309,7 @@ function projectunitary(U::MPO,prep::Array)
   M = ITensor[]
   s = firstsiteinds(U)
   for j in 1:length(U)
-    push!(M,U[j] * initstate(st[j],s[j]))
+    push!(M,U[j] * inputstate(st[j],s[j]))
   end
   return noprime!(MPS(M))
 end
@@ -371,8 +370,8 @@ function getsamples(N::Int64, gates::Vector{<:Tuple}, nshots::Int64;
     localbasis = (isnothing(localbasis) ? ["X","Y","Z"] : localbasis)
     
     bases = randombases(N, nshots;
-                      localbasis = localbasis,
-                      ndistinctbases = ndistinctbases)
+                        localbasis = localbasis,
+                        ndistinctbases = ndistinctbases)
     
     preps = randompreparations(N, nshots, inputstates = inputstates,
                                ndistinctstates = ndistinctstates)

--- a/src/circuits/runcircuit.jl
+++ b/src/circuits/runcircuit.jl
@@ -32,7 +32,7 @@ function qubits(sites::Vector{<:Index}, states::Vector{String};
 
   if N == 1
     s1 = sites[1]
-    state1 = initstate(states[1])
+    state1 = inputstate(states[1])
     if eltype(state1) <: Complex
       ψ[1] = complex(ψ[1])
     end
@@ -46,7 +46,7 @@ function qubits(sites::Vector{<:Index}, states::Vector{String};
   # Set first site
   s1 = sites[1]
   l1 = linkind(ψ, 1)
-  state1 = initstate(states[1])
+  state1 = inputstate(states[1])
   if eltype(state1) <: Complex
     ψ[1] = complex(ψ[1])
   end
@@ -59,7 +59,7 @@ function qubits(sites::Vector{<:Index}, states::Vector{String};
     sn = sites[n]
     ln_1 = linkind(ψ, n-1)
     ln = linkind(ψ, n)
-    state_n = initstate(states[n])
+    state_n = inputstate(states[n])
     if eltype(state_n) <: Complex
       ψ[n] = complex(ψ[n])
     end
@@ -71,7 +71,7 @@ function qubits(sites::Vector{<:Index}, states::Vector{String};
   # Set last site N
   sN = sites[N]
   lN_1 = linkind(ψ, N-1)
-  state_N = initstate(states[N])
+  state_N = inputstate(states[N])
   if eltype(state_N) <: Complex
     ψ[N] = complex(ψ[N])
   end

--- a/src/circuits/runcircuit.jl
+++ b/src/circuits/runcircuit.jl
@@ -11,11 +11,77 @@ Initialize qubits to:
 qubits(N::Int; mixed::Bool=false) =
   qubits(siteinds("Qubit", N); mixed=mixed)
 
-qubits(sites::Vector{<:Index}; mixed::Bool=false) = 
-  mixed ? MPO(productMPS(sites, "0")) : productMPS(sites, "0") 
+function qubits(sites::Vector{<:Index}; mixed::Bool = false)
+  ψ = productMPS(sites, "0")
+  mixed && return MPO(ψ)
+  return ψ
+end
 
 qubits(M::Union{MPS,MPO,LPDO}; mixed::Bool=false) =
-  qubits(hilbertspace(M); mixed=mixed)
+  qubits(hilbertspace(M); mixed = mixed)
+
+qubits(N::Int, states::Vector{String}; mixed::Bool=false) =
+  qubits(siteinds("Qubit", N), states; mixed=mixed)
+
+function qubits(sites::Vector{<:Index}, states::Vector{String};
+                mixed::Bool = false)
+  N = length(sites)
+  @assert N == length(states)
+
+  ψ = productMPS(sites, "0")
+
+  if N == 1
+    s1 = sites[1]
+    state1 = initstate(states[1])
+    if eltype(state1) <: Complex
+      ψ[1] = complex(ψ[1])
+    end
+    for j in 1:dim(s1)
+      ψ[1][s1 => j] = state1[j]
+    end
+    mixed && return MPO(ψ)
+    return ψ
+  end
+
+  # Set first site
+  s1 = sites[1]
+  l1 = linkind(ψ, 1)
+  state1 = initstate(states[1])
+  if eltype(state1) <: Complex
+    ψ[1] = complex(ψ[1])
+  end
+  for j in 1:dim(s1)
+    ψ[1][s1 => j, l1 => 1] = state1[j]
+  end
+
+  # Set sites 2:N-1
+  for n in 2:N-1
+    sn = sites[n]
+    ln_1 = linkind(ψ, n-1)
+    ln = linkind(ψ, n)
+    state_n = initstate(states[n])
+    if eltype(state_n) <: Complex
+      ψ[n] = complex(ψ[n])
+    end
+    for j in 1:dim(sn)
+      ψ[n][sn => j, ln_1 => 1, ln => 1] = state_n[j]
+    end
+  end
+  
+  # Set last site N
+  sN = sites[N]
+  lN_1 = linkind(ψ, N-1)
+  state_N = initstate(states[N])
+  if eltype(state_N) <: Complex
+    ψ[N] = complex(ψ[N])
+  end
+  for j in 1:dim(sN)
+    ψ[N][sN => j, lN_1 => 1] = state_N[j]
+  end
+  
+  mixed && return MPO(ψ)
+  return ψ
+end
 
 """ 
     resetqubits!(M::Union{MPS,MPO})

--- a/src/circuits/runcircuit.jl
+++ b/src/circuits/runcircuit.jl
@@ -228,7 +228,7 @@ function runcircuit(M::Union{MPS, MPO}, gates::Vector{<:Tuple};
                     noise = nothing,
                     apply_dag = nothing, 
                     cutoff = 1e-15,
-                    maxdim = 10000)
+                    maxdim = 10_000)
   gate_tensors = buildcircuit(M, gates; noise = noise) 
   return runcircuit(M, gate_tensors;
                     cutoff = cutoff,

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -11,6 +11,7 @@ export
 # circuits/gates.jl
   # Methods
   gate,
+  initstate,
   # Macros
   @GateName_str,
 

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -11,7 +11,7 @@ export
 # circuits/gates.jl
   # Methods
   gate,
-  initstate,
+  inputstate,
   # Macros
   @GateName_str,
 

--- a/src/randomstates.jl
+++ b/src/randomstates.jl
@@ -6,14 +6,17 @@ Each bulk tensor has one site index, and two link indices. The components of eac
 tensor, with type `ElT`, are randomly drawn from a uniform distribution centered 
 around zero, with width `σ`.
 """
-function random_mps(ElT::Type{<:Number},sites::Vector{<: Index},χ::Int64,σ::Float64) 
-  d = 2 # Dimension of the local Hilbert space
+function random_mps(ElT::Type{<:Number},
+                    sites::Vector{<: Index},
+                    χ::Int64,
+                    σ::Float64) 
+  d = dim(sites[1]) # Dimension of the local Hilbert space
   N = length(sites)
   links = [Index(χ; tags="Link, l=$l") for l in 1:N-1]
   M = ITensor[]
   if N == 1
     rand_mat = σ * (ones(d) - 2 * rand(d))
-    if (ElT == Complex{Float64})
+    if ElT <: Complex
       rand_mat += im * σ * (ones(d) - 2 * rand(d))
     end
     push!(M, ITensor(rand_mat, sites[1]))
@@ -21,20 +24,20 @@ function random_mps(ElT::Type{<:Number},sites::Vector{<: Index},χ::Int64,σ::Fl
   end
   # Site 1 
   rand_mat = σ * (ones(d,χ) - 2*rand(d,χ))
-  if (ElT == Complex{Float64})
+  if ElT <: Complex
     rand_mat += im * σ * (ones(d,χ) - 2*rand(d,χ)) 
   end
   push!(M,ITensor(rand_mat,sites[1],links[1]))
   for j in 2:N-1
     rand_mat = σ * (ones(χ,d,χ) - 2*rand(χ,d,χ))
-    if (ElT == Complex{Float64})
+    if ElT <: Complex
       rand_mat += im * σ * (ones(χ,d,χ) - 2*rand(χ,d,χ))
     end
     push!(M,ITensor(rand_mat,links[j-1],sites[j],links[j]))
   end
   # Site N
   rand_mat = σ * (ones(χ,d) - 2*rand(χ,d))
-  if (ElT == Complex{Float64})
+  if ElT <: Complex
     rand_mat += im * σ * (ones(χ,d) - 2*rand(χ,d))
   end
   push!(M,ITensor(rand_mat,links[N-1],sites[N]))
@@ -54,7 +57,7 @@ If `processtags=true`, add the tag `input` to the bra, and the tag `output`
 to the ket.
 """
 function random_mpo(ElT::Type{<:Number},sites::Vector{<: Index},χ::Int64,σ::Float64;processtags::Bool=false)
-  d = 2 # Dimension of the local Hilbert space
+  d = dim(sites[1]) # Dimension of the local Hilbert space
   #@show sites
   N = length(sites)
   links = [Index(χ; tags="Link, l=$l") for l in 1:N-1]
@@ -62,7 +65,7 @@ function random_mpo(ElT::Type{<:Number},sites::Vector{<: Index},χ::Int64,σ::Fl
   M = ITensor[]
   if N == 1
     rand_mat = σ * (ones(d,d) - 2 * rand(d,d))
-    if (ElT == Complex{Float64})
+    if ElT <: Complex
       rand_mat += im * σ * (ones(d,d) - 2 * rand(d,d))
     end
     push!(M, ITensor(rand_mat, sites[1]',sites[1]))
@@ -71,20 +74,20 @@ function random_mpo(ElT::Type{<:Number},sites::Vector{<: Index},χ::Int64,σ::Fl
 
   # Site 1 
   rand_mat = σ * (ones(d,χ,d) - 2*rand(d,χ,d))
-  if (ElT == Complex{Float64})
+  if ElT <: Complex
     rand_mat += im * σ * (ones(d,χ,d) - 2*rand(d,χ,d))
   end
   push!(M,ITensor(rand_mat,sites[1]',links[1],sites[1]))
   for j in 2:N-1
     rand_mat = σ * (ones(d,χ,d,χ) - 2*rand(d,χ,d,χ))
-    if (ElT == Complex{Float64})
+    if ElT <: Complex
       rand_mat += im * σ * (ones(d,χ,d,χ) - 2*rand(d,χ,d,χ))
     end
     push!(M,ITensor(rand_mat,sites[j]',links[j-1],sites[j],links[j]))
   end
   # Site N
   rand_mat = σ * (ones(d,χ,d) - 2*rand(d,χ,d))
-  if (ElT == Complex{Float64})
+  if ElT <: Complex
     rand_mat += im * σ * (ones(d,χ,d) - 2*rand(d,χ,d))
   end
   push!(M,ITensor(rand_mat,sites[N]',links[N-1],sites[N]))
@@ -109,9 +112,11 @@ the Hilbert spacee `sites`. Each bulk tensor has one site index, one kraus index
 and two link indices. The components of each tensor, with type `ElT`, are 
 randomly drawn from a uniform distribution centered around zero, with width `σ`.
 """
-function random_lpdo(ElT::Type{<:Number},sites::Vector{<: Index},χ::Int64,ξ::Int64,σ::Float64;
+function random_lpdo(ElT::Type{<:Number},
+                     sites::Vector{<: Index},
+                     χ::Int64, ξ::Int64, σ::Float64;
                     purifier_tag = ts"Purifier")
-  d = 2 # Dimension of the local Hilbert space
+  d = dim(sites[1]) # Dimension of the local Hilbert space
   N = length(sites)
   links = [Index(χ; tags="Link, l=$l") for l in 1:N-1]
   kraus = [Index(ξ; tags=addtags(purifier_tag, "k=$s")) for s in 1:N]
@@ -120,7 +125,7 @@ function random_lpdo(ElT::Type{<:Number},sites::Vector{<: Index},χ::Int64,ξ::I
   if N == 1
     # Site 1 
     rand_mat = σ * (ones(d,ξ) - 2*rand(rng,d,ξ))
-    if (ElT == Complex{Float64})
+    if ElT <: Complex
       rand_mat += im * σ * (ones(d,ξ) - 2*rand(rng,d,ξ))
     end
     push!(M,ITensor(rand_mat,sites[1],kraus[1]))
@@ -129,21 +134,21 @@ function random_lpdo(ElT::Type{<:Number},sites::Vector{<: Index},χ::Int64,ξ::I
 
   # Site 1 
   rand_mat = σ * (ones(d,χ,ξ) - 2*rand(d,χ,ξ))
-  if (ElT == Complex{Float64})
+  if ElT <: Complex
     rand_mat += im * σ * (ones(d,χ,ξ) - 2*rand(d,χ,ξ))
   end
   push!(M,ITensor(rand_mat,sites[1],links[1],kraus[1]))
   # Site 2..N-1
   for j in 2:N-1
     rand_mat = σ * (ones(d,χ,ξ,χ) - 2*rand(d,χ,ξ,χ))
-    if (ElT == Complex{Float64})
+    if ElT <: Complex
       rand_mat += im * σ * (ones(d,χ,ξ,χ) - 2*rand(d,χ,ξ,χ))
     end
     push!(M,ITensor(rand_mat,sites[j],links[j-1],kraus[j],links[j]))
   end
   # Site N
   rand_mat = σ * (ones(d,χ,ξ) - 2*rand(d,χ,ξ))
-  if (ElT == Complex{Float64})
+  if ElT <: Complex
     rand_mat += im * σ * (ones(d,χ,ξ) - 2*rand(d,χ,ξ))
   end
   push!(M,ITensor(rand_mat,sites[N],links[N-1],kraus[N]))
@@ -161,9 +166,11 @@ to input and output indices, one kraus index,and two link indices. The component
 of each tensor, with type `ElT`, are randomly drawn from a uniform distribution 
 centered around zero, with width `σ`.
 """
-function random_choi(ElT::Type{<:Number},sites::Vector{<: Index},χ::Int64,ξ::Int64,σ::Float64;
-                    purifier_tag = ts"Purifier")
-  d = 2 # Dimension of the local Hilbert space
+function random_choi(ElT::Type{<: Number},
+                     sites::Vector{<: Index},
+                     χ::Int64, ξ::Int64, σ::Float64;
+                     purifier_tag = ts"Purifier")
+  d = dim(sites[1]) # Dimension of the local Hilbert space
   N = length(sites)
   links = [Index(χ; tags="Link, l=$l") for l in 1:N-1]
   kraus = [Index(ξ; tags=addtags(purifier_tag, "k=$s")) for s in 1:N]
@@ -172,7 +179,7 @@ function random_choi(ElT::Type{<:Number},sites::Vector{<: Index},χ::Int64,ξ::I
   if N == 1
     # Site 1 
     rand_mat = σ * (ones(d,d,ξ) - 2*rand(d,d,ξ))
-    if (ElT == Complex{Float64})
+    if ElT <: Complex
       rand_mat += im * σ * (ones(d,d,ξ) - 2*rand(d,d,ξ))
     end
     push!(M,ITensor(rand_mat,sites[1],sites[1]',kraus[1]))
@@ -181,21 +188,21 @@ function random_choi(ElT::Type{<:Number},sites::Vector{<: Index},χ::Int64,ξ::I
 
   # Site 1 
   rand_mat = σ * (ones(d,d,χ,ξ) - 2*rand(d,d,χ,ξ))
-  if (ElT == Complex{Float64})
+  if ElT <: Complex
     rand_mat += im * σ * (ones(d,d,χ,ξ) - 2*rand(d,d,χ,ξ))
   end
   push!(M,ITensor(rand_mat,sites[1],sites[1]',links[1],kraus[1]))
   # Site 2..N-1
   for j in 2:N-1
     rand_mat = σ * (ones(d,d,χ,ξ,χ) - 2*rand(d,d,χ,ξ,χ))
-    if (ElT == Complex{Float64})
+    if ElT <: Complex
       rand_mat += im * σ * (ones(d,d,χ,ξ,χ) - 2*rand(d,d,χ,ξ,χ))
     end
     push!(M,ITensor(rand_mat,sites[j],sites[j]',links[j-1],kraus[j],links[j]))
   end
   # Site N
   rand_mat = σ * (ones(d,d,χ,ξ) - 2*rand(d,d,χ,ξ))
-  if (ElT == Complex{Float64})
+  if ElT <: Complex
     rand_mat += im * σ * (ones(d,d,χ,ξ) - 2*rand(d,d,χ,ξ))
   end
   push!(M,ITensor(rand_mat,sites[N],sites[N]',links[N-1],kraus[N]))
@@ -219,55 +226,63 @@ end
 """
     randomstate(N::Int64; kwargs...)
 
-Generates a random quantum state of N qubits
+    randomstate(ElT::Type{<: Number}, N::Int64; kwargs...)
+
+Generates a random quantum state of N qubits.
+
+Optionally, specify an element type, such as `randomstate(Float64, 10)` for a random real state (by default it is complex).
 
 # Arguments
   - `N`: number of qubits
   - `mixed`: if false (default), generate a random MPS; if true, generates a random LPDO
-  - `init`: initialization criteria: `"randompars"` initializes random tensor components; 
-    `"circuit` initializes with a random quantum circuit (MPS only).
-  - `σ`: size of the 0-centered uniform distribution in `init="randpars"`. 
+  - `alg`: algorithm used for initialization: `"rand"` initializes random tensor elements; 
+    `"circuit"` initializes with a random quantum circuit (MPS only).
+  - `σ`: size of the 0-centered uniform distribution in `alg="rand"`. 
   - `χ`: bond dimension of the MPS/LPDO
   - 'ξ`: kraus dimension (LPDO)
-  - `normalize`: if true, return normalize state
-  - `cplx`: if true (default), returns complex-valued state
+  - `normalize`: if true, return normalized state
 """
-function randomstate(N::Int64; kwargs...)
+function randomstate(ElT::Type{<: Number}, N::Int64; kwargs...)
   sites = siteinds("Qubit", N)
-  return randomstate(sites; kwargs...)
+  return randomstate(ElT, sites; kwargs...)
 end
 
-function randomstate(sites::Vector{<:Index}; kwargs...)
+randomstate(N::Int64; kwargs...) =
+  randomstate(ComplexF64, N; kwargs...)
+
+function randomstate(ElT::Type{<: Number}, sites::Vector{<: Index};
+                     kwargs...)
   mixed::Bool = get(kwargs,:mixed,false)
   lpdo::Bool  = get(kwargs,:lpdo,true)
   if !mixed
-    return randomstate(sites,MPS; kwargs...)
+    return randomstate(ElT, MPS, sites; kwargs...)
   else
     if lpdo
-      return randomstate(sites,LPDO; kwargs...)
+      return randomstate(ElT, LPDO, sites; kwargs...)
     else
-      return randomstate(sites,MPO; kwargs...)
+      return randomstate(ElT, MPO, sites; kwargs...)
     end
   end
 end
 
-function randomstate(sites::Vector{<:Index},T::Type; kwargs...)
-  χ::Int64 = get(kwargs,:χ,2)
-  ξ::Int64 = get(kwargs,:ξ,2)
-  σ::Float64 = get(kwargs,:σ,0.1)
-  purifier_tag = get(kwargs,:purifier_tag,ts"Purifier")
-  init::String = get(kwargs,:init,"randpars")
-  cplx::Bool = get(kwargs,:complex,true)
-  normalize::Bool = get(kwargs,:normalize,false)
+randomstate(sites::Vector{<: Index}; kwargs...) =
+  randomstate(ComplexF64, sites; kwargs...)
 
-  ElT = (cplx ? Complex{Float64} : Float64)
+function randomstate(ElT::Type{<: Number}, T::Type,
+                     sites::Vector{<: Index}; kwargs...)
+  χ::Int64 = get(kwargs, :χ, 1)
+  ξ::Int64 = get(kwargs, :ξ, 1)
+  σ::Float64 = get(kwargs, :σ, 0.1)
+  purifier_tag = get(kwargs,:purifier_tag,ts"Purifier")
+  alg::String = get(kwargs,:alg,"rand")
+  normalize::Bool = get(kwargs,:normalize,false)
 
   if T == MPS
     # Build MPS by random parameter initialization
-    if init == "randpars"
+    if alg == "rand"
       M =  random_mps(ElT,sites,χ,σ)
     # Build MPS using a quantum circuit
-    elseif init=="circuit"
+    elseif alg=="circuit"
       M = randomMPS(ElT,sites,χ)
     end
   elseif T == MPO
@@ -277,7 +292,8 @@ function randomstate(sites::Vector{<:Index},T::Type; kwargs...)
   else
     error("ansatz type not recognized")
   end
-  return (normalize ? normalize!(M) : M)
+  normalize && normalize!(M)
+  return M
 end
 
 """
@@ -286,48 +302,61 @@ end
 Generate a random state with same Hilbert space (i.e. site indices)
 of a reference state `M`.
 """
-function randomstate(M::Union{MPS,MPO,LPDO}; kwargs...)
+function randomstate(ElT::Type{<: Number}, M::Union{MPS,MPO,LPDO}; kwargs...)
   hM = hilbertspace(M)
-  return randomstate(hM;kwargs...)
+  return randomstate(ElT, hM; kwargs...)
 end
+
+randomstate(M::Union{MPS,MPO,LPDO}; kwargs...) =
+  randomstate(ComplexF64, M; kwargs...)
 
 """
     randomprocess(N::Int64; kwargs...)
 
+    randomprocess(ElT::Type{<: Number}, N::Int64; kwargs...)
+
 Generates a random quantum procecss of N qubits.
+
+Optionally choose the element type with calls like `randomprocess(Float64, 10)` (by default it is complex).
 
 # Arguments
   - `N`: number of qubits
   - `mixed`: if false (default), generates a random MPO; if true, generates a random LPDO.
-  - `init`: initialization criteria, set to `"randompars"` (see `randomstate`).
-  - `σ`: size of the 0-centered uniform distribution in `init="randpars"`. 
+  - `alg`: initialization criteria, set to `"randompars"` (see `randomstate`).
+  - `σ`: size of the 0-centered uniform distribution in `alg="rand"`. 
   - `χ`: bond dimension of the MPO/LPDO.
   - 'ξ`: kraus dimension (LPDO).
-  - `cplx`: if true (default), returns complex-valued state.
 """
-function randomprocess(N::Int64; kwargs...)
+function randomprocess(ElT::Type{<: Number}, N::Int64; kwargs...)
   sites = siteinds("Qubit", N)
-  return randomprocess(sites; kwargs...)
+  return randomprocess(ElT, sites; kwargs...)
 end
 
-function randomprocess(sites::Vector{<:Index}; kwargs...)
+randomprocess(N::Int64; kwargs...) =
+  randomprocess(ComplexF64, N; kwargs...)
+
+function randomprocess(ElT::Type{<: Number}, sites::Vector{<:Index};
+                       kwargs...)
   mixed::Bool = get(kwargs,:mixed,false)
-  return (mixed ? randomprocess(sites,Choi; kwargs...) : randomprocess(sites,MPO; kwargs...))
+  if mixed 
+    return randomprocess(ElT, Choi, sites; kwargs...)
+  end
+  return randomprocess(ElT, MPO, sites; kwargs...)
 end
 
-function randomprocess(sites::Vector{<:Index},T::Type; kwargs...)
-  χ::Int64 = get(kwargs,:χ,2)
-  ξ::Int64 = get(kwargs,:ξ,2)
+randomprocess(sites::Vector{<:Index}; kwargs...) =
+  randomprocess(ComplexF64, sites; kwargs...)
+
+function randomprocess(ElT::Type{<: Number}, T::Type,
+                       sites::Vector{<: Index}; kwargs...)
+  χ::Int64 = get(kwargs,:χ,1)
+  ξ::Int64 = get(kwargs,:ξ,1)
   σ::Float64 = get(kwargs,:σ,0.1)
   purifier_tag = get(kwargs,:purifier_tag,ts"Purifier")
-  init::String = get(kwargs,:init,"randpars")
-  cplx::Bool = get(kwargs,:complex,true)
-  
-  ElT = (cplx ? Complex{Float64} : Float64)
-  
+  alg::String = get(kwargs,:alg,"rand")
   processtags = !(any(x -> hastags(x,"Input") , sites))
   if T == MPO
-    if init == "randpars"
+    if alg == "rand"
       M = random_mpo(ElT,sites,χ,σ;processtags=processtags)
     else
       error("randomMPO with circuit initialization not implemented yet")
@@ -340,27 +369,39 @@ function randomprocess(sites::Vector{<:Index},T::Type; kwargs...)
   return M
 end
 
+randomprocess(T::Type, sites::Vector{<: Index}; kwargs...) =
+  randomprocess(ComplexF64, T, sites; kwargs...)
+
 """
     randomprocess(M::Union{MPS,MPO}; kwargs...)
 
 Generate a random process with same Hilbert space (i.e. input
 and output indices)of a reference process `M`.
 """
-function randomprocess(M::Union{MPS,MPO}; kwargs...)
-  mixed = get(kwargs,:mixed,false)
+function randomprocess(ElT::Type{<: Number}, M::Union{MPS,MPO};
+                       kwargs...)
+  mixed = get(kwargs, :mixed, false)
   N = length(M)
   s = Index[]
   for j in 1:N
-    push!(s,firstind(M[j],tags="Site",plev=0))
+    push!(s, firstind(M[j], tags = "Site", plev = 0))
   end
-  proc = randomprocess(s; mixed=mixed,kwargs...)
+  proc = randomprocess(ElT, s; mixed = mixed, kwargs...)
   return proc
 end
 
+randomprocess(M::Union{MPS,MPO}; kwargs...) =
+  randomprocess(ComplexF64, M; kwargs...)
+
+randomprocess(ElT::Type{<: Number}, C::Choi; kwargs...) = 
+  randomprocess(ElT, C.M; kwargs...)
+
 randomprocess(C::Choi; kwargs...) = 
-  randomprocess(C.M; kwargs...)
+  randomprocess(ComplexF64, C; kwargs...)
+
+randomprocess(ElT::Type{<: Number}, L::LPDO; kwargs...) = 
+  randomprocess(ElT, L.X; kwargs...)
 
 randomprocess(L::LPDO; kwargs...) = 
-  randomprocess(L.X; kwargs...)
-
+  randomprocess(ComplexF64, L; kwargs...)
 

--- a/src/tomography.jl
+++ b/src/tomography.jl
@@ -125,54 +125,54 @@ function gradnll(L::LPDO{MPS},
     
     """ LEFT ENVIRONMENTS """
     if choi
-      L[nthread][1] .= ψdag[1] .* dag(gate(x[1],s[1]))
+      L[nthread][1] .= ψdag[1] .* dag(initstate(x[1],s[1]))
     else
-      L[nthread][1] .= ψdag[1] .* gate(x[1],s[1])
+      L[nthread][1] .= ψdag[1] .* initstate(x[1],s[1])
     end
     for j in 2:N-1
       Lpsi[nthread][j] .= L[nthread][j-1] .* ψdag[j]
       if isodd(j) & choi
-        L[nthread][j] .= Lpsi[nthread][j] .* dag(gate(x[j],s[j]))
+        L[nthread][j] .= Lpsi[nthread][j] .* dag(initstate(x[j],s[j]))
       else
-        L[nthread][j] .= Lpsi[nthread][j] .* gate(x[j],s[j])
+        L[nthread][j] .= Lpsi[nthread][j] .* initstate(x[j],s[j])
       end
     end
     Lpsi[nthread][N] .= L[nthread][N-1] .* ψdag[N]
-    ψx = (Lpsi[nthread][N] * gate(x[N],s[N]))[]
+    ψx = (Lpsi[nthread][N] * initstate(x[N],s[N]))[]
     prob = abs2(ψx)
     loss[nthread] -= log(prob)/size(data)[1]
     
     """ RIGHT ENVIRONMENTS """
-    R[nthread][N] .= ψdag[N] .* gate(x[N],s[N])
+    R[nthread][N] .= ψdag[N] .* initstate(x[N],s[N])
     for j in reverse(2:N-1)
       Rpsi[nthread][j] .= ψdag[j] .* R[nthread][j+1]
       if isodd(j) & choi
-        R[nthread][j] .= Rpsi[nthread][j] .* dag(gate(x[j],s[j]))
+        R[nthread][j] .= Rpsi[nthread][j] .* dag(initstate(x[j],s[j]))
       else
-        R[nthread][j] .= Rpsi[nthread][j] .* gate(x[j],s[j])
+        R[nthread][j] .= Rpsi[nthread][j] .* initstate(x[j],s[j])
       end
     end
 
     """ GRADIENTS """
     # TODO: fuse into one call to mul!
     if choi
-      grads[nthread][1] .= dag(gate(x[1],s[1])) .* R[nthread][2]
+      grads[nthread][1] .= dag(initstate(x[1],s[1])) .* R[nthread][2]
     else
-      grads[nthread][1] .= gate(x[1],s[1]) .* R[nthread][2]
+      grads[nthread][1] .= initstate(x[1],s[1]) .* R[nthread][2]
     end
     gradients[nthread][1] .+= (1 / (sqrt_localnorms[1] * ψx)) .* grads[nthread][1]
     for j in 2:N-1
       if isodd(j) & choi
-        Rpsi[nthread][j] .= L[nthread][j-1] .* dag(gate(x[j],s[j]))
+        Rpsi[nthread][j] .= L[nthread][j-1] .* dag(initstate(x[j],s[j]))
       else
-        Rpsi[nthread][j] .= L[nthread][j-1] .* gate(x[j],s[j])
+        Rpsi[nthread][j] .= L[nthread][j-1] .* initstate(x[j],s[j])
       end
         
       # TODO: fuse into one call to mul!
       grads[nthread][j] .= Rpsi[nthread][j] .* R[nthread][j+1]
       gradients[nthread][j] .+= (1 / (sqrt_localnorms[j] * ψx)) .* grads[nthread][j]
     end
-    grads[nthread][N] .= L[nthread][N-1] .* gate(x[N], s[N])
+    grads[nthread][N] .= L[nthread][N-1] .* initstate(x[N], s[N])
     gradients[nthread][N] .+= (1 / (sqrt_localnorms[N] * ψx)) .* grads[nthread][N]
   end
   
@@ -308,22 +308,22 @@ function gradnll(L::LPDO{MPO}, data::Array;
     
     """ LEFT ENVIRONMENTS """
     if choi
-      T[nthread][1] .= lpdo[1] .* gate(x[1],s[1])
+      T[nthread][1] .= lpdo[1] .* initstate(x[1],s[1])
       L[nthread][1] .= prime(T[nthread][1],"Link") .* dag(T[nthread][1])
     else
-      T[nthread][1] .= lpdo[1] .* dag(gate(x[1],s[1]))
+      T[nthread][1] .= lpdo[1] .* dag(initstate(x[1],s[1]))
       L[nthread][1] .= prime(T[nthread][1],"Link") .* dag(T[nthread][1])
     end
     for j in 2:N-1
       if isodd(j) & choi
-        T[nthread][j] .= lpdo[j] .* gate(x[j],s[j])
+        T[nthread][j] .= lpdo[j] .* initstate(x[j],s[j])
       else
-        T[nthread][j] .= lpdo[j] .* dag(gate(x[j],s[j]))
+        T[nthread][j] .= lpdo[j] .* dag(initstate(x[j],s[j]))
       end
       Llpdo[nthread][j] .= prime(T[nthread][j],"Link") .* L[nthread][j-1]
       L[nthread][j] .= Llpdo[nthread][j] .* dag(T[nthread][j])
     end
-    T[nthread][N] .= lpdo[N] .* dag(gate(x[N],s[N]))
+    T[nthread][N] .= lpdo[N] .* dag(initstate(x[N],s[N]))
     prob = L[nthread][N-1] * prime(T[nthread][N],"Link")
     prob = prob * dag(T[nthread][N])
     prob = real(prob[])
@@ -338,30 +338,30 @@ function gradnll(L::LPDO{MPO}, data::Array;
     
     """ GRADIENTS """
     if choi
-      Tp[nthread][1] .= prime(lpdo[1],"Link") .* gate(x[1],s[1])
-      Agrad[nthread][1] .=  Tp[nthread][1] .* dag(gate(x[1],s[1]))
+      Tp[nthread][1] .= prime(lpdo[1],"Link") .* initstate(x[1],s[1])
+      Agrad[nthread][1] .=  Tp[nthread][1] .* dag(initstate(x[1],s[1]))
     else
-      Tp[nthread][1] .= prime(lpdo[1],"Link") .* dag(gate(x[1],s[1]))
-      Agrad[nthread][1] .=  Tp[nthread][1] .* gate(x[1],s[1])
+      Tp[nthread][1] .= prime(lpdo[1],"Link") .* dag(initstate(x[1],s[1]))
+      Agrad[nthread][1] .=  Tp[nthread][1] .* initstate(x[1],s[1])
     end
     grads[nthread][1] .= R[nthread][2] .* Agrad[nthread][1]
     gradients[nthread][1] .+= (1 / (sqrt_localnorms[1] * prob)) .* grads[nthread][1]
     for j in 2:N-1
       if isodd(j) & choi
-        Tp[nthread][j] .= prime(lpdo[j],"Link") .* gate(x[j],s[j])
+        Tp[nthread][j] .= prime(lpdo[j],"Link") .* initstate(x[j],s[j])
         Lgrad[nthread][j-1] .= L[nthread][j-1] .* Tp[nthread][j]
-        Agrad[nthread][j] .= Lgrad[nthread][j-1] .* dag(gate(x[j],s[j]))
+        Agrad[nthread][j] .= Lgrad[nthread][j-1] .* dag(initstate(x[j],s[j]))
       else
-        Tp[nthread][j] .= prime(lpdo[j],"Link") .* dag(gate(x[j],s[j]))
+        Tp[nthread][j] .= prime(lpdo[j],"Link") .* dag(initstate(x[j],s[j]))
         Lgrad[nthread][j-1] .= L[nthread][j-1] .* Tp[nthread][j]
-        Agrad[nthread][j] .= Lgrad[nthread][j-1] .* gate(x[j],s[j])
+        Agrad[nthread][j] .= Lgrad[nthread][j-1] .* initstate(x[j],s[j])
       end
       grads[nthread][j] .= R[nthread][j+1] .* Agrad[nthread][j] 
       gradients[nthread][j] .+= (1 / (sqrt_localnorms[j] * prob)) .* grads[nthread][j]
     end
-    Tp[nthread][N] .= prime(lpdo[N],"Link") .* dag(gate(x[N],s[N]))
+    Tp[nthread][N] .= prime(lpdo[N],"Link") .* dag(initstate(x[N],s[N]))
     Lgrad[nthread][N-1] .= L[nthread][N-1] .* Tp[nthread][N]
-    grads[nthread][N] .= Lgrad[nthread][N-1] .* gate(x[N],s[N])
+    grads[nthread][N] .= Lgrad[nthread][N-1] .* initstate(x[N],s[N])
     gradients[nthread][N] .+= (1 / (sqrt_localnorms[N] * prob)) .* grads[nthread][N]
   end
   
@@ -680,11 +680,11 @@ function nll(L::LPDO{MPS}, data::Array; choi::Bool = false)
   
   for n in 1:size(data)[1]
     x = data[n,:]
-    ψx = (choi ? dag(ψ[1]) * dag(gate(x[1],s[1])) :
-                 dag(ψ[1]) * gate(x[1],s[1]))
+    ψx = (choi ? dag(ψ[1]) * dag(initstate(x[1],s[1])) :
+                 dag(ψ[1]) * initstate(x[1],s[1]))
     for j in 2:N
-      ψ_r = (isodd(j) & choi ? ψ_r = dag(ψ[j]) * dag(gate(x[j],s[j])) :
-                               ψ_r = dag(ψ[j]) * gate(x[j],s[j]))
+      ψ_r = (isodd(j) & choi ? ψ_r = dag(ψ[j]) * dag(initstate(x[j],s[j])) :
+                               ψ_r = dag(ψ[j]) * initstate(x[j],s[j]))
       ψx = ψx * ψ_r
     end
     prob = abs2(ψx[])
@@ -717,8 +717,8 @@ function nll(L::LPDO{MPO}, data::Array; choi::Bool = false)
     # Project LPDO into the measurement eigenstates
     Φdag = dag(copy(lpdo))
     for j in 1:N
-      Φdag[j] = (isodd(j) & choi ? Φdag[j] = Φdag[j] * dag(gate(x[j],s[j])) :
-                                   Φdag[j] = Φdag[j] * gate(x[j],s[j]))
+      Φdag[j] = (isodd(j) & choi ? Φdag[j] = Φdag[j] * dag(initstate(x[j],s[j])) :
+                                   Φdag[j] = Φdag[j] * initstate(x[j],s[j]))
     end
     
     # Compute overlap

--- a/src/tomography.jl
+++ b/src/tomography.jl
@@ -125,54 +125,54 @@ function gradnll(L::LPDO{MPS},
     
     """ LEFT ENVIRONMENTS """
     if choi
-      L[nthread][1] .= ψdag[1] .* dag(state(x[1], s[1]))
+      L[nthread][1] .= ψdag[1] .* dag(gate(x[1],s[1]))
     else
-      L[nthread][1] .= ψdag[1] .* state(x[1], s[1])
+      L[nthread][1] .= ψdag[1] .* gate(x[1],s[1])
     end
     for j in 2:N-1
       Lpsi[nthread][j] .= L[nthread][j-1] .* ψdag[j]
       if isodd(j) & choi
-        L[nthread][j] .= Lpsi[nthread][j] .* dag(state(x[j], s[j]))
+        L[nthread][j] .= Lpsi[nthread][j] .* dag(gate(x[j],s[j]))
       else
-        L[nthread][j] .= Lpsi[nthread][j] .* state(x[j], s[j])
+        L[nthread][j] .= Lpsi[nthread][j] .* gate(x[j],s[j])
       end
     end
     Lpsi[nthread][N] .= L[nthread][N-1] .* ψdag[N]
-    ψx = (Lpsi[nthread][N] * state(x[N], s[N]))[]
+    ψx = (Lpsi[nthread][N] * gate(x[N],s[N]))[]
     prob = abs2(ψx)
     loss[nthread] -= log(prob)/size(data)[1]
     
     """ RIGHT ENVIRONMENTS """
-    R[nthread][N] .= ψdag[N] .* state(x[N], s[N])
+    R[nthread][N] .= ψdag[N] .* gate(x[N],s[N])
     for j in reverse(2:N-1)
       Rpsi[nthread][j] .= ψdag[j] .* R[nthread][j+1]
       if isodd(j) & choi
-        R[nthread][j] .= Rpsi[nthread][j] .* dag(state(x[j], s[j]))
+        R[nthread][j] .= Rpsi[nthread][j] .* dag(gate(x[j],s[j]))
       else
-        R[nthread][j] .= Rpsi[nthread][j] .* state(x[j], s[j])
+        R[nthread][j] .= Rpsi[nthread][j] .* gate(x[j],s[j])
       end
     end
 
     """ GRADIENTS """
     # TODO: fuse into one call to mul!
     if choi
-      grads[nthread][1] .= dag(state(x[1], s[1])) .* R[nthread][2]
+      grads[nthread][1] .= dag(gate(x[1],s[1])) .* R[nthread][2]
     else
-      grads[nthread][1] .= state(x[1], s[1]) .* R[nthread][2]
+      grads[nthread][1] .= gate(x[1],s[1]) .* R[nthread][2]
     end
     gradients[nthread][1] .+= (1 / (sqrt_localnorms[1] * ψx)) .* grads[nthread][1]
     for j in 2:N-1
       if isodd(j) & choi
-        Rpsi[nthread][j] .= L[nthread][j-1] .* dag(state(x[j], s[j]))
+        Rpsi[nthread][j] .= L[nthread][j-1] .* dag(gate(x[j],s[j]))
       else
-        Rpsi[nthread][j] .= L[nthread][j-1] .* state(x[j], s[j])
+        Rpsi[nthread][j] .= L[nthread][j-1] .* gate(x[j],s[j])
       end
         
       # TODO: fuse into one call to mul!
       grads[nthread][j] .= Rpsi[nthread][j] .* R[nthread][j+1]
       gradients[nthread][j] .+= (1 / (sqrt_localnorms[j] * ψx)) .* grads[nthread][j]
     end
-    grads[nthread][N] .= L[nthread][N-1] .* state(x[N], s[N])
+    grads[nthread][N] .= L[nthread][N-1] .* gate(x[N], s[N])
     gradients[nthread][N] .+= (1 / (sqrt_localnorms[N] * ψx)) .* grads[nthread][N]
   end
   
@@ -308,22 +308,22 @@ function gradnll(L::LPDO{MPO}, data::Array;
     
     """ LEFT ENVIRONMENTS """
     if choi
-      T[nthread][1] .= lpdo[1] .* state(x[1], s[1])
+      T[nthread][1] .= lpdo[1] .* gate(x[1],s[1])
       L[nthread][1] .= prime(T[nthread][1],"Link") .* dag(T[nthread][1])
     else
-      T[nthread][1] .= lpdo[1] .* dag(state(x[1], s[1]))
+      T[nthread][1] .= lpdo[1] .* dag(gate(x[1],s[1]))
       L[nthread][1] .= prime(T[nthread][1],"Link") .* dag(T[nthread][1])
     end
     for j in 2:N-1
       if isodd(j) & choi
-        T[nthread][j] .= lpdo[j] .* state(x[j], s[j])
+        T[nthread][j] .= lpdo[j] .* gate(x[j],s[j])
       else
-        T[nthread][j] .= lpdo[j] .* dag(state(x[j], s[j]))
+        T[nthread][j] .= lpdo[j] .* dag(gate(x[j],s[j]))
       end
       Llpdo[nthread][j] .= prime(T[nthread][j],"Link") .* L[nthread][j-1]
       L[nthread][j] .= Llpdo[nthread][j] .* dag(T[nthread][j])
     end
-    T[nthread][N] .= lpdo[N] .* dag(state(x[N], s[N]))
+    T[nthread][N] .= lpdo[N] .* dag(gate(x[N],s[N]))
     prob = L[nthread][N-1] * prime(T[nthread][N],"Link")
     prob = prob * dag(T[nthread][N])
     prob = real(prob[])
@@ -338,30 +338,30 @@ function gradnll(L::LPDO{MPO}, data::Array;
     
     """ GRADIENTS """
     if choi
-      Tp[nthread][1] .= prime(lpdo[1],"Link") .* state(x[1], s[1])
-      Agrad[nthread][1] .=  Tp[nthread][1] .* dag(state(x[1], s[1]))
+      Tp[nthread][1] .= prime(lpdo[1],"Link") .* gate(x[1],s[1])
+      Agrad[nthread][1] .=  Tp[nthread][1] .* dag(gate(x[1],s[1]))
     else
-      Tp[nthread][1] .= prime(lpdo[1],"Link") .* dag(state(x[1], s[1]))
-      Agrad[nthread][1] .=  Tp[nthread][1] .* state(x[1], s[1])
+      Tp[nthread][1] .= prime(lpdo[1],"Link") .* dag(gate(x[1],s[1]))
+      Agrad[nthread][1] .=  Tp[nthread][1] .* gate(x[1],s[1])
     end
     grads[nthread][1] .= R[nthread][2] .* Agrad[nthread][1]
     gradients[nthread][1] .+= (1 / (sqrt_localnorms[1] * prob)) .* grads[nthread][1]
     for j in 2:N-1
       if isodd(j) & choi
-        Tp[nthread][j] .= prime(lpdo[j],"Link") .* state(x[j], s[j])
+        Tp[nthread][j] .= prime(lpdo[j],"Link") .* gate(x[j],s[j])
         Lgrad[nthread][j-1] .= L[nthread][j-1] .* Tp[nthread][j]
-        Agrad[nthread][j] .= Lgrad[nthread][j-1] .* dag(state(x[j], s[j]))
+        Agrad[nthread][j] .= Lgrad[nthread][j-1] .* dag(gate(x[j],s[j]))
       else
-        Tp[nthread][j] .= prime(lpdo[j],"Link") .* dag(state(x[j], s[j]))
+        Tp[nthread][j] .= prime(lpdo[j],"Link") .* dag(gate(x[j],s[j]))
         Lgrad[nthread][j-1] .= L[nthread][j-1] .* Tp[nthread][j]
-        Agrad[nthread][j] .= Lgrad[nthread][j-1] .* state(x[j], s[j])
+        Agrad[nthread][j] .= Lgrad[nthread][j-1] .* gate(x[j],s[j])
       end
       grads[nthread][j] .= R[nthread][j+1] .* Agrad[nthread][j] 
       gradients[nthread][j] .+= (1 / (sqrt_localnorms[j] * prob)) .* grads[nthread][j]
     end
-    Tp[nthread][N] .= prime(lpdo[N],"Link") .* dag(state(x[N], s[N]))
+    Tp[nthread][N] .= prime(lpdo[N],"Link") .* dag(gate(x[N],s[N]))
     Lgrad[nthread][N-1] .= L[nthread][N-1] .* Tp[nthread][N]
-    grads[nthread][N] .= Lgrad[nthread][N-1] .* state(x[N], s[N])
+    grads[nthread][N] .= Lgrad[nthread][N-1] .* gate(x[N],s[N])
     gradients[nthread][N] .+= (1 / (sqrt_localnorms[N] * prob)) .* grads[nthread][N]
   end
   
@@ -680,11 +680,11 @@ function nll(L::LPDO{MPS}, data::Array; choi::Bool = false)
   
   for n in 1:size(data)[1]
     x = data[n,:]
-    ψx = (choi ? dag(ψ[1]) * dag(state(x[1], s[1])) :
-                 dag(ψ[1]) * state(x[1], s[1]))
+    ψx = (choi ? dag(ψ[1]) * dag(gate(x[1],s[1])) :
+                 dag(ψ[1]) * gate(x[1],s[1]))
     for j in 2:N
-      ψ_r = (isodd(j) & choi ? ψ_r = dag(ψ[j]) * dag(state(x[j], s[j])) :
-                               ψ_r = dag(ψ[j]) * state(x[j], s[j]))
+      ψ_r = (isodd(j) & choi ? ψ_r = dag(ψ[j]) * dag(gate(x[j],s[j])) :
+                               ψ_r = dag(ψ[j]) * gate(x[j],s[j]))
       ψx = ψx * ψ_r
     end
     prob = abs2(ψx[])
@@ -717,8 +717,8 @@ function nll(L::LPDO{MPO}, data::Array; choi::Bool = false)
     # Project LPDO into the measurement eigenstates
     Φdag = dag(copy(lpdo))
     for j in 1:N
-      Φdag[j] = (isodd(j) & choi ? Φdag[j] = Φdag[j] * dag(state(x[j], s[j])) :
-                                   Φdag[j] = Φdag[j] * state(x[j], s[j]))
+      Φdag[j] = (isodd(j) & choi ? Φdag[j] = Φdag[j] * dag(gate(x[j],s[j])) :
+                                   Φdag[j] = Φdag[j] * gate(x[j],s[j]))
     end
     
     # Compute overlap

--- a/src/tomography.jl
+++ b/src/tomography.jl
@@ -125,54 +125,54 @@ function gradnll(L::LPDO{MPS},
     
     """ LEFT ENVIRONMENTS """
     if choi
-      L[nthread][1] .= ψdag[1] .* dag(gate(x[1],s[1]))
+      L[nthread][1] .= ψdag[1] .* dag(state(x[1],s[1]))
     else
-      L[nthread][1] .= ψdag[1] .* gate(x[1],s[1])
+      L[nthread][1] .= ψdag[1] .* state(x[1],s[1])
     end
     for j in 2:N-1
       Lpsi[nthread][j] .= L[nthread][j-1] .* ψdag[j]
       if isodd(j) & choi
-        L[nthread][j] .= Lpsi[nthread][j] .* dag(gate(x[j],s[j]))
+        L[nthread][j] .= Lpsi[nthread][j] .* dag(state(x[j],s[j]))
       else
-        L[nthread][j] .= Lpsi[nthread][j] .* gate(x[j],s[j])
+        L[nthread][j] .= Lpsi[nthread][j] .* state(x[j],s[j])
       end
     end
     Lpsi[nthread][N] .= L[nthread][N-1] .* ψdag[N]
-    ψx = (Lpsi[nthread][N] * gate(x[N],s[N]))[]
+    ψx = (Lpsi[nthread][N] * state(x[N],s[N]))[]
     prob = abs2(ψx)
     loss[nthread] -= log(prob)/size(data)[1]
     
     """ RIGHT ENVIRONMENTS """
-    R[nthread][N] .= ψdag[N] .* gate(x[N],s[N])
+    R[nthread][N] .= ψdag[N] .* state(x[N],s[N])
     for j in reverse(2:N-1)
       Rpsi[nthread][j] .= ψdag[j] .* R[nthread][j+1]
       if isodd(j) & choi
-        R[nthread][j] .= Rpsi[nthread][j] .* dag(gate(x[j],s[j]))
+        R[nthread][j] .= Rpsi[nthread][j] .* dag(state(x[j],s[j]))
       else
-        R[nthread][j] .= Rpsi[nthread][j] .* gate(x[j],s[j])
+        R[nthread][j] .= Rpsi[nthread][j] .* state(x[j],s[j])
       end
     end
 
     """ GRADIENTS """
     # TODO: fuse into one call to mul!
     if choi
-      grads[nthread][1] .= dag(gate(x[1],s[1])) .* R[nthread][2]
+      grads[nthread][1] .= dag(state(x[1],s[1])) .* R[nthread][2]
     else
-      grads[nthread][1] .= gate(x[1],s[1]) .* R[nthread][2]
+      grads[nthread][1] .= state(x[1],s[1]) .* R[nthread][2]
     end
     gradients[nthread][1] .+= (1 / (sqrt_localnorms[1] * ψx)) .* grads[nthread][1]
     for j in 2:N-1
       if isodd(j) & choi
-        Rpsi[nthread][j] .= L[nthread][j-1] .* dag(gate(x[j],s[j]))
+        Rpsi[nthread][j] .= L[nthread][j-1] .* dag(state(x[j],s[j]))
       else
-        Rpsi[nthread][j] .= L[nthread][j-1] .* gate(x[j],s[j])
+        Rpsi[nthread][j] .= L[nthread][j-1] .* state(x[j],s[j])
       end
         
       # TODO: fuse into one call to mul!
       grads[nthread][j] .= Rpsi[nthread][j] .* R[nthread][j+1]
       gradients[nthread][j] .+= (1 / (sqrt_localnorms[j] * ψx)) .* grads[nthread][j]
     end
-    grads[nthread][N] .= L[nthread][N-1] .* gate(x[N], s[N])
+    grads[nthread][N] .= L[nthread][N-1] .* state(x[N], s[N])
     gradients[nthread][N] .+= (1 / (sqrt_localnorms[N] * ψx)) .* grads[nthread][N]
   end
   
@@ -308,22 +308,22 @@ function gradnll(L::LPDO{MPO}, data::Array;
     
     """ LEFT ENVIRONMENTS """
     if choi
-      T[nthread][1] .= lpdo[1] .* gate(x[1],s[1])
+      T[nthread][1] .= lpdo[1] .* state(x[1],s[1])
       L[nthread][1] .= prime(T[nthread][1],"Link") .* dag(T[nthread][1])
     else
-      T[nthread][1] .= lpdo[1] .* dag(gate(x[1],s[1]))
+      T[nthread][1] .= lpdo[1] .* dag(state(x[1],s[1]))
       L[nthread][1] .= prime(T[nthread][1],"Link") .* dag(T[nthread][1])
     end
     for j in 2:N-1
       if isodd(j) & choi
-        T[nthread][j] .= lpdo[j] .* gate(x[j],s[j])
+        T[nthread][j] .= lpdo[j] .* state(x[j],s[j])
       else
-        T[nthread][j] .= lpdo[j] .* dag(gate(x[j],s[j]))
+        T[nthread][j] .= lpdo[j] .* dag(state(x[j],s[j]))
       end
       Llpdo[nthread][j] .= prime(T[nthread][j],"Link") .* L[nthread][j-1]
       L[nthread][j] .= Llpdo[nthread][j] .* dag(T[nthread][j])
     end
-    T[nthread][N] .= lpdo[N] .* dag(gate(x[N],s[N]))
+    T[nthread][N] .= lpdo[N] .* dag(state(x[N],s[N]))
     prob = L[nthread][N-1] * prime(T[nthread][N],"Link")
     prob = prob * dag(T[nthread][N])
     prob = real(prob[])
@@ -338,30 +338,30 @@ function gradnll(L::LPDO{MPO}, data::Array;
     
     """ GRADIENTS """
     if choi
-      Tp[nthread][1] .= prime(lpdo[1],"Link") .* gate(x[1],s[1])
-      Agrad[nthread][1] .=  Tp[nthread][1] .* dag(gate(x[1],s[1]))
+      Tp[nthread][1] .= prime(lpdo[1],"Link") .* state(x[1],s[1])
+      Agrad[nthread][1] .=  Tp[nthread][1] .* dag(state(x[1],s[1]))
     else
-      Tp[nthread][1] .= prime(lpdo[1],"Link") .* dag(gate(x[1],s[1]))
-      Agrad[nthread][1] .=  Tp[nthread][1] .* gate(x[1],s[1])
+      Tp[nthread][1] .= prime(lpdo[1],"Link") .* dag(state(x[1],s[1]))
+      Agrad[nthread][1] .=  Tp[nthread][1] .* state(x[1],s[1])
     end
     grads[nthread][1] .= R[nthread][2] .* Agrad[nthread][1]
     gradients[nthread][1] .+= (1 / (sqrt_localnorms[1] * prob)) .* grads[nthread][1]
     for j in 2:N-1
       if isodd(j) & choi
-        Tp[nthread][j] .= prime(lpdo[j],"Link") .* gate(x[j],s[j])
+        Tp[nthread][j] .= prime(lpdo[j],"Link") .* state(x[j],s[j])
         Lgrad[nthread][j-1] .= L[nthread][j-1] .* Tp[nthread][j]
-        Agrad[nthread][j] .= Lgrad[nthread][j-1] .* dag(gate(x[j],s[j]))
+        Agrad[nthread][j] .= Lgrad[nthread][j-1] .* dag(state(x[j],s[j]))
       else
-        Tp[nthread][j] .= prime(lpdo[j],"Link") .* dag(gate(x[j],s[j]))
+        Tp[nthread][j] .= prime(lpdo[j],"Link") .* dag(state(x[j],s[j]))
         Lgrad[nthread][j-1] .= L[nthread][j-1] .* Tp[nthread][j]
-        Agrad[nthread][j] .= Lgrad[nthread][j-1] .* gate(x[j],s[j])
+        Agrad[nthread][j] .= Lgrad[nthread][j-1] .* state(x[j],s[j])
       end
       grads[nthread][j] .= R[nthread][j+1] .* Agrad[nthread][j] 
       gradients[nthread][j] .+= (1 / (sqrt_localnorms[j] * prob)) .* grads[nthread][j]
     end
-    Tp[nthread][N] .= prime(lpdo[N],"Link") .* dag(gate(x[N],s[N]))
+    Tp[nthread][N] .= prime(lpdo[N],"Link") .* dag(state(x[N],s[N]))
     Lgrad[nthread][N-1] .= L[nthread][N-1] .* Tp[nthread][N]
-    grads[nthread][N] .= Lgrad[nthread][N-1] .* gate(x[N],s[N])
+    grads[nthread][N] .= Lgrad[nthread][N-1] .* state(x[N],s[N])
     gradients[nthread][N] .+= (1 / (sqrt_localnorms[N] * prob)) .* grads[nthread][N]
   end
   

--- a/src/tomography.jl
+++ b/src/tomography.jl
@@ -680,11 +680,11 @@ function nll(L::LPDO{MPS}, data::Array; choi::Bool = false)
   
   for n in 1:size(data)[1]
     x = data[n,:]
-    ψx = (choi ? dag(ψ[1]) * dag(gate(x[1],s[1])) :
-                 dag(ψ[1]) * gate(x[1],s[1]))
+    ψx = (choi ? dag(ψ[1]) * dag(state(x[1],s[1])) :
+                 dag(ψ[1]) * state(x[1],s[1]))
     for j in 2:N
-      ψ_r = (isodd(j) & choi ? ψ_r = dag(ψ[j]) * dag(gate(x[j],s[j])) :
-                               ψ_r = dag(ψ[j]) * gate(x[j],s[j]))
+      ψ_r = (isodd(j) & choi ? ψ_r = dag(ψ[j]) * dag(state(x[j],s[j])) :
+                               ψ_r = dag(ψ[j]) * state(x[j],s[j]))
       ψx = ψx * ψ_r
     end
     prob = abs2(ψx[])
@@ -717,8 +717,8 @@ function nll(L::LPDO{MPO}, data::Array; choi::Bool = false)
     # Project LPDO into the measurement eigenstates
     Φdag = dag(copy(lpdo))
     for j in 1:N
-      Φdag[j] = (isodd(j) & choi ? Φdag[j] = Φdag[j] * dag(gate(x[j],s[j])) :
-                                   Φdag[j] = Φdag[j] * gate(x[j],s[j]))
+      Φdag[j] = (isodd(j) & choi ? Φdag[j] = Φdag[j] * dag(state(x[j],s[j])) :
+                                   Φdag[j] = Φdag[j] * state(x[j],s[j]))
     end
     
     # Compute overlap

--- a/src/tomography.jl
+++ b/src/tomography.jl
@@ -125,54 +125,54 @@ function gradnll(L::LPDO{MPS},
     
     """ LEFT ENVIRONMENTS """
     if choi
-      L[nthread][1] .= ψdag[1] .* dag(initstate(x[1],s[1]))
+      L[nthread][1] .= ψdag[1] .* dag(inputstate(x[1],s[1]))
     else
-      L[nthread][1] .= ψdag[1] .* initstate(x[1],s[1])
+      L[nthread][1] .= ψdag[1] .* inputstate(x[1],s[1])
     end
     for j in 2:N-1
       Lpsi[nthread][j] .= L[nthread][j-1] .* ψdag[j]
       if isodd(j) & choi
-        L[nthread][j] .= Lpsi[nthread][j] .* dag(initstate(x[j],s[j]))
+        L[nthread][j] .= Lpsi[nthread][j] .* dag(inputstate(x[j],s[j]))
       else
-        L[nthread][j] .= Lpsi[nthread][j] .* initstate(x[j],s[j])
+        L[nthread][j] .= Lpsi[nthread][j] .* inputstate(x[j],s[j])
       end
     end
     Lpsi[nthread][N] .= L[nthread][N-1] .* ψdag[N]
-    ψx = (Lpsi[nthread][N] * initstate(x[N],s[N]))[]
+    ψx = (Lpsi[nthread][N] * inputstate(x[N],s[N]))[]
     prob = abs2(ψx)
     loss[nthread] -= log(prob)/size(data)[1]
     
     """ RIGHT ENVIRONMENTS """
-    R[nthread][N] .= ψdag[N] .* initstate(x[N],s[N])
+    R[nthread][N] .= ψdag[N] .* inputstate(x[N],s[N])
     for j in reverse(2:N-1)
       Rpsi[nthread][j] .= ψdag[j] .* R[nthread][j+1]
       if isodd(j) & choi
-        R[nthread][j] .= Rpsi[nthread][j] .* dag(initstate(x[j],s[j]))
+        R[nthread][j] .= Rpsi[nthread][j] .* dag(inputstate(x[j],s[j]))
       else
-        R[nthread][j] .= Rpsi[nthread][j] .* initstate(x[j],s[j])
+        R[nthread][j] .= Rpsi[nthread][j] .* inputstate(x[j],s[j])
       end
     end
 
     """ GRADIENTS """
     # TODO: fuse into one call to mul!
     if choi
-      grads[nthread][1] .= dag(initstate(x[1],s[1])) .* R[nthread][2]
+      grads[nthread][1] .= dag(inputstate(x[1],s[1])) .* R[nthread][2]
     else
-      grads[nthread][1] .= initstate(x[1],s[1]) .* R[nthread][2]
+      grads[nthread][1] .= inputstate(x[1],s[1]) .* R[nthread][2]
     end
     gradients[nthread][1] .+= (1 / (sqrt_localnorms[1] * ψx)) .* grads[nthread][1]
     for j in 2:N-1
       if isodd(j) & choi
-        Rpsi[nthread][j] .= L[nthread][j-1] .* dag(initstate(x[j],s[j]))
+        Rpsi[nthread][j] .= L[nthread][j-1] .* dag(inputstate(x[j],s[j]))
       else
-        Rpsi[nthread][j] .= L[nthread][j-1] .* initstate(x[j],s[j])
+        Rpsi[nthread][j] .= L[nthread][j-1] .* inputstate(x[j],s[j])
       end
         
       # TODO: fuse into one call to mul!
       grads[nthread][j] .= Rpsi[nthread][j] .* R[nthread][j+1]
       gradients[nthread][j] .+= (1 / (sqrt_localnorms[j] * ψx)) .* grads[nthread][j]
     end
-    grads[nthread][N] .= L[nthread][N-1] .* initstate(x[N], s[N])
+    grads[nthread][N] .= L[nthread][N-1] .* inputstate(x[N], s[N])
     gradients[nthread][N] .+= (1 / (sqrt_localnorms[N] * ψx)) .* grads[nthread][N]
   end
   
@@ -308,22 +308,22 @@ function gradnll(L::LPDO{MPO}, data::Array;
     
     """ LEFT ENVIRONMENTS """
     if choi
-      T[nthread][1] .= lpdo[1] .* initstate(x[1],s[1])
+      T[nthread][1] .= lpdo[1] .* inputstate(x[1],s[1])
       L[nthread][1] .= prime(T[nthread][1],"Link") .* dag(T[nthread][1])
     else
-      T[nthread][1] .= lpdo[1] .* dag(initstate(x[1],s[1]))
+      T[nthread][1] .= lpdo[1] .* dag(inputstate(x[1],s[1]))
       L[nthread][1] .= prime(T[nthread][1],"Link") .* dag(T[nthread][1])
     end
     for j in 2:N-1
       if isodd(j) & choi
-        T[nthread][j] .= lpdo[j] .* initstate(x[j],s[j])
+        T[nthread][j] .= lpdo[j] .* inputstate(x[j],s[j])
       else
-        T[nthread][j] .= lpdo[j] .* dag(initstate(x[j],s[j]))
+        T[nthread][j] .= lpdo[j] .* dag(inputstate(x[j],s[j]))
       end
       Llpdo[nthread][j] .= prime(T[nthread][j],"Link") .* L[nthread][j-1]
       L[nthread][j] .= Llpdo[nthread][j] .* dag(T[nthread][j])
     end
-    T[nthread][N] .= lpdo[N] .* dag(initstate(x[N],s[N]))
+    T[nthread][N] .= lpdo[N] .* dag(inputstate(x[N],s[N]))
     prob = L[nthread][N-1] * prime(T[nthread][N],"Link")
     prob = prob * dag(T[nthread][N])
     prob = real(prob[])
@@ -338,30 +338,30 @@ function gradnll(L::LPDO{MPO}, data::Array;
     
     """ GRADIENTS """
     if choi
-      Tp[nthread][1] .= prime(lpdo[1],"Link") .* initstate(x[1],s[1])
-      Agrad[nthread][1] .=  Tp[nthread][1] .* dag(initstate(x[1],s[1]))
+      Tp[nthread][1] .= prime(lpdo[1],"Link") .* inputstate(x[1],s[1])
+      Agrad[nthread][1] .=  Tp[nthread][1] .* dag(inputstate(x[1],s[1]))
     else
-      Tp[nthread][1] .= prime(lpdo[1],"Link") .* dag(initstate(x[1],s[1]))
-      Agrad[nthread][1] .=  Tp[nthread][1] .* initstate(x[1],s[1])
+      Tp[nthread][1] .= prime(lpdo[1],"Link") .* dag(inputstate(x[1],s[1]))
+      Agrad[nthread][1] .=  Tp[nthread][1] .* inputstate(x[1],s[1])
     end
     grads[nthread][1] .= R[nthread][2] .* Agrad[nthread][1]
     gradients[nthread][1] .+= (1 / (sqrt_localnorms[1] * prob)) .* grads[nthread][1]
     for j in 2:N-1
       if isodd(j) & choi
-        Tp[nthread][j] .= prime(lpdo[j],"Link") .* initstate(x[j],s[j])
+        Tp[nthread][j] .= prime(lpdo[j],"Link") .* inputstate(x[j],s[j])
         Lgrad[nthread][j-1] .= L[nthread][j-1] .* Tp[nthread][j]
-        Agrad[nthread][j] .= Lgrad[nthread][j-1] .* dag(initstate(x[j],s[j]))
+        Agrad[nthread][j] .= Lgrad[nthread][j-1] .* dag(inputstate(x[j],s[j]))
       else
-        Tp[nthread][j] .= prime(lpdo[j],"Link") .* dag(initstate(x[j],s[j]))
+        Tp[nthread][j] .= prime(lpdo[j],"Link") .* dag(inputstate(x[j],s[j]))
         Lgrad[nthread][j-1] .= L[nthread][j-1] .* Tp[nthread][j]
-        Agrad[nthread][j] .= Lgrad[nthread][j-1] .* initstate(x[j],s[j])
+        Agrad[nthread][j] .= Lgrad[nthread][j-1] .* inputstate(x[j],s[j])
       end
       grads[nthread][j] .= R[nthread][j+1] .* Agrad[nthread][j] 
       gradients[nthread][j] .+= (1 / (sqrt_localnorms[j] * prob)) .* grads[nthread][j]
     end
-    Tp[nthread][N] .= prime(lpdo[N],"Link") .* dag(initstate(x[N],s[N]))
+    Tp[nthread][N] .= prime(lpdo[N],"Link") .* dag(inputstate(x[N],s[N]))
     Lgrad[nthread][N-1] .= L[nthread][N-1] .* Tp[nthread][N]
-    grads[nthread][N] .= Lgrad[nthread][N-1] .* initstate(x[N],s[N])
+    grads[nthread][N] .= Lgrad[nthread][N-1] .* inputstate(x[N],s[N])
     gradients[nthread][N] .+= (1 / (sqrt_localnorms[N] * prob)) .* grads[nthread][N]
   end
   
@@ -680,11 +680,11 @@ function nll(L::LPDO{MPS}, data::Array; choi::Bool = false)
   
   for n in 1:size(data)[1]
     x = data[n,:]
-    ψx = (choi ? dag(ψ[1]) * dag(initstate(x[1],s[1])) :
-                 dag(ψ[1]) * initstate(x[1],s[1]))
+    ψx = (choi ? dag(ψ[1]) * dag(inputstate(x[1],s[1])) :
+                 dag(ψ[1]) * inputstate(x[1],s[1]))
     for j in 2:N
-      ψ_r = (isodd(j) & choi ? ψ_r = dag(ψ[j]) * dag(initstate(x[j],s[j])) :
-                               ψ_r = dag(ψ[j]) * initstate(x[j],s[j]))
+      ψ_r = (isodd(j) & choi ? ψ_r = dag(ψ[j]) * dag(inputstate(x[j],s[j])) :
+                               ψ_r = dag(ψ[j]) * inputstate(x[j],s[j]))
       ψx = ψx * ψ_r
     end
     prob = abs2(ψx[])
@@ -717,8 +717,8 @@ function nll(L::LPDO{MPO}, data::Array; choi::Bool = false)
     # Project LPDO into the measurement eigenstates
     Φdag = dag(copy(lpdo))
     for j in 1:N
-      Φdag[j] = (isodd(j) & choi ? Φdag[j] = Φdag[j] * dag(initstate(x[j],s[j])) :
-                                   Φdag[j] = Φdag[j] * initstate(x[j],s[j]))
+      Φdag[j] = (isodd(j) & choi ? Φdag[j] = Φdag[j] * dag(inputstate(x[j],s[j])) :
+                                   Φdag[j] = Φdag[j] * inputstate(x[j],s[j]))
     end
     
     # Compute overlap

--- a/src/tomography.jl
+++ b/src/tomography.jl
@@ -125,54 +125,54 @@ function gradnll(L::LPDO{MPS},
     
     """ LEFT ENVIRONMENTS """
     if choi
-      L[nthread][1] .= ψdag[1] .* dag(gate(x[1],s[1]))
+      L[nthread][1] .= ψdag[1] .* dag(state(x[1], s[1]))
     else
-      L[nthread][1] .= ψdag[1] .* gate(x[1],s[1])
+      L[nthread][1] .= ψdag[1] .* state(x[1], s[1])
     end
     for j in 2:N-1
       Lpsi[nthread][j] .= L[nthread][j-1] .* ψdag[j]
       if isodd(j) & choi
-        L[nthread][j] .= Lpsi[nthread][j] .* dag(gate(x[j],s[j]))
+        L[nthread][j] .= Lpsi[nthread][j] .* dag(state(x[j], s[j]))
       else
-        L[nthread][j] .= Lpsi[nthread][j] .* gate(x[j],s[j])
+        L[nthread][j] .= Lpsi[nthread][j] .* state(x[j], s[j])
       end
     end
     Lpsi[nthread][N] .= L[nthread][N-1] .* ψdag[N]
-    ψx = (Lpsi[nthread][N] * gate(x[N],s[N]))[]
+    ψx = (Lpsi[nthread][N] * state(x[N], s[N]))[]
     prob = abs2(ψx)
     loss[nthread] -= log(prob)/size(data)[1]
     
     """ RIGHT ENVIRONMENTS """
-    R[nthread][N] .= ψdag[N] .* gate(x[N],s[N])
+    R[nthread][N] .= ψdag[N] .* state(x[N], s[N])
     for j in reverse(2:N-1)
       Rpsi[nthread][j] .= ψdag[j] .* R[nthread][j+1]
       if isodd(j) & choi
-        R[nthread][j] .= Rpsi[nthread][j] .* dag(gate(x[j],s[j]))
+        R[nthread][j] .= Rpsi[nthread][j] .* dag(state(x[j], s[j]))
       else
-        R[nthread][j] .= Rpsi[nthread][j] .* gate(x[j],s[j])
+        R[nthread][j] .= Rpsi[nthread][j] .* state(x[j], s[j])
       end
     end
 
     """ GRADIENTS """
     # TODO: fuse into one call to mul!
     if choi
-      grads[nthread][1] .= dag(gate(x[1],s[1])) .* R[nthread][2]
+      grads[nthread][1] .= dag(state(x[1], s[1])) .* R[nthread][2]
     else
-      grads[nthread][1] .= gate(x[1],s[1]) .* R[nthread][2]
+      grads[nthread][1] .= state(x[1], s[1]) .* R[nthread][2]
     end
     gradients[nthread][1] .+= (1 / (sqrt_localnorms[1] * ψx)) .* grads[nthread][1]
     for j in 2:N-1
       if isodd(j) & choi
-        Rpsi[nthread][j] .= L[nthread][j-1] .* dag(gate(x[j],s[j]))
+        Rpsi[nthread][j] .= L[nthread][j-1] .* dag(state(x[j], s[j]))
       else
-        Rpsi[nthread][j] .= L[nthread][j-1] .* gate(x[j],s[j])
+        Rpsi[nthread][j] .= L[nthread][j-1] .* state(x[j], s[j])
       end
         
       # TODO: fuse into one call to mul!
       grads[nthread][j] .= Rpsi[nthread][j] .* R[nthread][j+1]
       gradients[nthread][j] .+= (1 / (sqrt_localnorms[j] * ψx)) .* grads[nthread][j]
     end
-    grads[nthread][N] .= L[nthread][N-1] .* gate(x[N], s[N])
+    grads[nthread][N] .= L[nthread][N-1] .* state(x[N], s[N])
     gradients[nthread][N] .+= (1 / (sqrt_localnorms[N] * ψx)) .* grads[nthread][N]
   end
   
@@ -308,22 +308,22 @@ function gradnll(L::LPDO{MPO}, data::Array;
     
     """ LEFT ENVIRONMENTS """
     if choi
-      T[nthread][1] .= lpdo[1] .* gate(x[1],s[1])
+      T[nthread][1] .= lpdo[1] .* state(x[1], s[1])
       L[nthread][1] .= prime(T[nthread][1],"Link") .* dag(T[nthread][1])
     else
-      T[nthread][1] .= lpdo[1] .* dag(gate(x[1],s[1]))
+      T[nthread][1] .= lpdo[1] .* dag(state(x[1], s[1]))
       L[nthread][1] .= prime(T[nthread][1],"Link") .* dag(T[nthread][1])
     end
     for j in 2:N-1
       if isodd(j) & choi
-        T[nthread][j] .= lpdo[j] .* gate(x[j],s[j])
+        T[nthread][j] .= lpdo[j] .* state(x[j], s[j])
       else
-        T[nthread][j] .= lpdo[j] .* dag(gate(x[j],s[j]))
+        T[nthread][j] .= lpdo[j] .* dag(state(x[j], s[j]))
       end
       Llpdo[nthread][j] .= prime(T[nthread][j],"Link") .* L[nthread][j-1]
       L[nthread][j] .= Llpdo[nthread][j] .* dag(T[nthread][j])
     end
-    T[nthread][N] .= lpdo[N] .* dag(gate(x[N],s[N]))
+    T[nthread][N] .= lpdo[N] .* dag(state(x[N], s[N]))
     prob = L[nthread][N-1] * prime(T[nthread][N],"Link")
     prob = prob * dag(T[nthread][N])
     prob = real(prob[])
@@ -338,30 +338,30 @@ function gradnll(L::LPDO{MPO}, data::Array;
     
     """ GRADIENTS """
     if choi
-      Tp[nthread][1] .= prime(lpdo[1],"Link") .* gate(x[1],s[1])
-      Agrad[nthread][1] .=  Tp[nthread][1] .* dag(gate(x[1],s[1]))
+      Tp[nthread][1] .= prime(lpdo[1],"Link") .* state(x[1], s[1])
+      Agrad[nthread][1] .=  Tp[nthread][1] .* dag(state(x[1], s[1]))
     else
-      Tp[nthread][1] .= prime(lpdo[1],"Link") .* dag(gate(x[1],s[1]))
-      Agrad[nthread][1] .=  Tp[nthread][1] .* gate(x[1],s[1])
+      Tp[nthread][1] .= prime(lpdo[1],"Link") .* dag(state(x[1], s[1]))
+      Agrad[nthread][1] .=  Tp[nthread][1] .* state(x[1], s[1])
     end
     grads[nthread][1] .= R[nthread][2] .* Agrad[nthread][1]
     gradients[nthread][1] .+= (1 / (sqrt_localnorms[1] * prob)) .* grads[nthread][1]
     for j in 2:N-1
       if isodd(j) & choi
-        Tp[nthread][j] .= prime(lpdo[j],"Link") .* gate(x[j],s[j])
+        Tp[nthread][j] .= prime(lpdo[j],"Link") .* state(x[j], s[j])
         Lgrad[nthread][j-1] .= L[nthread][j-1] .* Tp[nthread][j]
-        Agrad[nthread][j] .= Lgrad[nthread][j-1] .* dag(gate(x[j],s[j]))
+        Agrad[nthread][j] .= Lgrad[nthread][j-1] .* dag(state(x[j], s[j]))
       else
-        Tp[nthread][j] .= prime(lpdo[j],"Link") .* dag(gate(x[j],s[j]))
+        Tp[nthread][j] .= prime(lpdo[j],"Link") .* dag(state(x[j], s[j]))
         Lgrad[nthread][j-1] .= L[nthread][j-1] .* Tp[nthread][j]
-        Agrad[nthread][j] .= Lgrad[nthread][j-1] .* gate(x[j],s[j])
+        Agrad[nthread][j] .= Lgrad[nthread][j-1] .* state(x[j], s[j])
       end
       grads[nthread][j] .= R[nthread][j+1] .* Agrad[nthread][j] 
       gradients[nthread][j] .+= (1 / (sqrt_localnorms[j] * prob)) .* grads[nthread][j]
     end
-    Tp[nthread][N] .= prime(lpdo[N],"Link") .* dag(gate(x[N],s[N]))
+    Tp[nthread][N] .= prime(lpdo[N],"Link") .* dag(state(x[N], s[N]))
     Lgrad[nthread][N-1] .= L[nthread][N-1] .* Tp[nthread][N]
-    grads[nthread][N] .= Lgrad[nthread][N-1] .* gate(x[N],s[N])
+    grads[nthread][N] .= Lgrad[nthread][N-1] .* state(x[N], s[N])
     gradients[nthread][N] .+= (1 / (sqrt_localnorms[N] * prob)) .* grads[nthread][N]
   end
   
@@ -680,11 +680,11 @@ function nll(L::LPDO{MPS}, data::Array; choi::Bool = false)
   
   for n in 1:size(data)[1]
     x = data[n,:]
-    ψx = (choi ? dag(ψ[1]) * dag(gate(x[1],s[1])) :
-                 dag(ψ[1]) * gate(x[1],s[1]))
+    ψx = (choi ? dag(ψ[1]) * dag(state(x[1], s[1])) :
+                 dag(ψ[1]) * state(x[1], s[1]))
     for j in 2:N
-      ψ_r = (isodd(j) & choi ? ψ_r = dag(ψ[j]) * dag(gate(x[j],s[j])) :
-                               ψ_r = dag(ψ[j]) * gate(x[j],s[j]))
+      ψ_r = (isodd(j) & choi ? ψ_r = dag(ψ[j]) * dag(state(x[j], s[j])) :
+                               ψ_r = dag(ψ[j]) * state(x[j], s[j]))
       ψx = ψx * ψ_r
     end
     prob = abs2(ψx[])
@@ -717,8 +717,8 @@ function nll(L::LPDO{MPO}, data::Array; choi::Bool = false)
     # Project LPDO into the measurement eigenstates
     Φdag = dag(copy(lpdo))
     for j in 1:N
-      Φdag[j] = (isodd(j) & choi ? Φdag[j] = Φdag[j] * dag(gate(x[j],s[j])) :
-                                   Φdag[j] = Φdag[j] * gate(x[j],s[j]))
+      Φdag[j] = (isodd(j) & choi ? Φdag[j] = Φdag[j] * dag(state(x[j], s[j])) :
+                                   Φdag[j] = Φdag[j] * state(x[j], s[j]))
     end
     
     # Compute overlap

--- a/src/tomography.jl
+++ b/src/tomography.jl
@@ -125,54 +125,54 @@ function gradnll(L::LPDO{MPS},
     
     """ LEFT ENVIRONMENTS """
     if choi
-      L[nthread][1] .= ψdag[1] .* dag(state(x[1],s[1]))
+      L[nthread][1] .= ψdag[1] .* dag(gate(x[1],s[1]))
     else
-      L[nthread][1] .= ψdag[1] .* state(x[1],s[1])
+      L[nthread][1] .= ψdag[1] .* gate(x[1],s[1])
     end
     for j in 2:N-1
       Lpsi[nthread][j] .= L[nthread][j-1] .* ψdag[j]
       if isodd(j) & choi
-        L[nthread][j] .= Lpsi[nthread][j] .* dag(state(x[j],s[j]))
+        L[nthread][j] .= Lpsi[nthread][j] .* dag(gate(x[j],s[j]))
       else
-        L[nthread][j] .= Lpsi[nthread][j] .* state(x[j],s[j])
+        L[nthread][j] .= Lpsi[nthread][j] .* gate(x[j],s[j])
       end
     end
     Lpsi[nthread][N] .= L[nthread][N-1] .* ψdag[N]
-    ψx = (Lpsi[nthread][N] * state(x[N],s[N]))[]
+    ψx = (Lpsi[nthread][N] * gate(x[N],s[N]))[]
     prob = abs2(ψx)
     loss[nthread] -= log(prob)/size(data)[1]
     
     """ RIGHT ENVIRONMENTS """
-    R[nthread][N] .= ψdag[N] .* state(x[N],s[N])
+    R[nthread][N] .= ψdag[N] .* gate(x[N],s[N])
     for j in reverse(2:N-1)
       Rpsi[nthread][j] .= ψdag[j] .* R[nthread][j+1]
       if isodd(j) & choi
-        R[nthread][j] .= Rpsi[nthread][j] .* dag(state(x[j],s[j]))
+        R[nthread][j] .= Rpsi[nthread][j] .* dag(gate(x[j],s[j]))
       else
-        R[nthread][j] .= Rpsi[nthread][j] .* state(x[j],s[j])
+        R[nthread][j] .= Rpsi[nthread][j] .* gate(x[j],s[j])
       end
     end
 
     """ GRADIENTS """
     # TODO: fuse into one call to mul!
     if choi
-      grads[nthread][1] .= dag(state(x[1],s[1])) .* R[nthread][2]
+      grads[nthread][1] .= dag(gate(x[1],s[1])) .* R[nthread][2]
     else
-      grads[nthread][1] .= state(x[1],s[1]) .* R[nthread][2]
+      grads[nthread][1] .= gate(x[1],s[1]) .* R[nthread][2]
     end
     gradients[nthread][1] .+= (1 / (sqrt_localnorms[1] * ψx)) .* grads[nthread][1]
     for j in 2:N-1
       if isodd(j) & choi
-        Rpsi[nthread][j] .= L[nthread][j-1] .* dag(state(x[j],s[j]))
+        Rpsi[nthread][j] .= L[nthread][j-1] .* dag(gate(x[j],s[j]))
       else
-        Rpsi[nthread][j] .= L[nthread][j-1] .* state(x[j],s[j])
+        Rpsi[nthread][j] .= L[nthread][j-1] .* gate(x[j],s[j])
       end
         
       # TODO: fuse into one call to mul!
       grads[nthread][j] .= Rpsi[nthread][j] .* R[nthread][j+1]
       gradients[nthread][j] .+= (1 / (sqrt_localnorms[j] * ψx)) .* grads[nthread][j]
     end
-    grads[nthread][N] .= L[nthread][N-1] .* state(x[N], s[N])
+    grads[nthread][N] .= L[nthread][N-1] .* gate(x[N], s[N])
     gradients[nthread][N] .+= (1 / (sqrt_localnorms[N] * ψx)) .* grads[nthread][N]
   end
   
@@ -308,22 +308,22 @@ function gradnll(L::LPDO{MPO}, data::Array;
     
     """ LEFT ENVIRONMENTS """
     if choi
-      T[nthread][1] .= lpdo[1] .* state(x[1],s[1])
+      T[nthread][1] .= lpdo[1] .* gate(x[1],s[1])
       L[nthread][1] .= prime(T[nthread][1],"Link") .* dag(T[nthread][1])
     else
-      T[nthread][1] .= lpdo[1] .* dag(state(x[1],s[1]))
+      T[nthread][1] .= lpdo[1] .* dag(gate(x[1],s[1]))
       L[nthread][1] .= prime(T[nthread][1],"Link") .* dag(T[nthread][1])
     end
     for j in 2:N-1
       if isodd(j) & choi
-        T[nthread][j] .= lpdo[j] .* state(x[j],s[j])
+        T[nthread][j] .= lpdo[j] .* gate(x[j],s[j])
       else
-        T[nthread][j] .= lpdo[j] .* dag(state(x[j],s[j]))
+        T[nthread][j] .= lpdo[j] .* dag(gate(x[j],s[j]))
       end
       Llpdo[nthread][j] .= prime(T[nthread][j],"Link") .* L[nthread][j-1]
       L[nthread][j] .= Llpdo[nthread][j] .* dag(T[nthread][j])
     end
-    T[nthread][N] .= lpdo[N] .* dag(state(x[N],s[N]))
+    T[nthread][N] .= lpdo[N] .* dag(gate(x[N],s[N]))
     prob = L[nthread][N-1] * prime(T[nthread][N],"Link")
     prob = prob * dag(T[nthread][N])
     prob = real(prob[])
@@ -338,30 +338,30 @@ function gradnll(L::LPDO{MPO}, data::Array;
     
     """ GRADIENTS """
     if choi
-      Tp[nthread][1] .= prime(lpdo[1],"Link") .* state(x[1],s[1])
-      Agrad[nthread][1] .=  Tp[nthread][1] .* dag(state(x[1],s[1]))
+      Tp[nthread][1] .= prime(lpdo[1],"Link") .* gate(x[1],s[1])
+      Agrad[nthread][1] .=  Tp[nthread][1] .* dag(gate(x[1],s[1]))
     else
-      Tp[nthread][1] .= prime(lpdo[1],"Link") .* dag(state(x[1],s[1]))
-      Agrad[nthread][1] .=  Tp[nthread][1] .* state(x[1],s[1])
+      Tp[nthread][1] .= prime(lpdo[1],"Link") .* dag(gate(x[1],s[1]))
+      Agrad[nthread][1] .=  Tp[nthread][1] .* gate(x[1],s[1])
     end
     grads[nthread][1] .= R[nthread][2] .* Agrad[nthread][1]
     gradients[nthread][1] .+= (1 / (sqrt_localnorms[1] * prob)) .* grads[nthread][1]
     for j in 2:N-1
       if isodd(j) & choi
-        Tp[nthread][j] .= prime(lpdo[j],"Link") .* state(x[j],s[j])
+        Tp[nthread][j] .= prime(lpdo[j],"Link") .* gate(x[j],s[j])
         Lgrad[nthread][j-1] .= L[nthread][j-1] .* Tp[nthread][j]
-        Agrad[nthread][j] .= Lgrad[nthread][j-1] .* dag(state(x[j],s[j]))
+        Agrad[nthread][j] .= Lgrad[nthread][j-1] .* dag(gate(x[j],s[j]))
       else
-        Tp[nthread][j] .= prime(lpdo[j],"Link") .* dag(state(x[j],s[j]))
+        Tp[nthread][j] .= prime(lpdo[j],"Link") .* dag(gate(x[j],s[j]))
         Lgrad[nthread][j-1] .= L[nthread][j-1] .* Tp[nthread][j]
-        Agrad[nthread][j] .= Lgrad[nthread][j-1] .* state(x[j],s[j])
+        Agrad[nthread][j] .= Lgrad[nthread][j-1] .* gate(x[j],s[j])
       end
       grads[nthread][j] .= R[nthread][j+1] .* Agrad[nthread][j] 
       gradients[nthread][j] .+= (1 / (sqrt_localnorms[j] * prob)) .* grads[nthread][j]
     end
-    Tp[nthread][N] .= prime(lpdo[N],"Link") .* dag(state(x[N],s[N]))
+    Tp[nthread][N] .= prime(lpdo[N],"Link") .* dag(gate(x[N],s[N]))
     Lgrad[nthread][N-1] .= L[nthread][N-1] .* Tp[nthread][N]
-    grads[nthread][N] .= Lgrad[nthread][N-1] .* state(x[N],s[N])
+    grads[nthread][N] .= Lgrad[nthread][N-1] .* gate(x[N],s[N])
     gradients[nthread][N] .+= (1 / (sqrt_localnorms[N] * prob)) .* grads[nthread][N]
   end
   
@@ -680,11 +680,11 @@ function nll(L::LPDO{MPS}, data::Array; choi::Bool = false)
   
   for n in 1:size(data)[1]
     x = data[n,:]
-    ψx = (choi ? dag(ψ[1]) * dag(state(x[1],s[1])) :
-                 dag(ψ[1]) * state(x[1],s[1]))
+    ψx = (choi ? dag(ψ[1]) * dag(gate(x[1],s[1])) :
+                 dag(ψ[1]) * gate(x[1],s[1]))
     for j in 2:N
-      ψ_r = (isodd(j) & choi ? ψ_r = dag(ψ[j]) * dag(state(x[j],s[j])) :
-                               ψ_r = dag(ψ[j]) * state(x[j],s[j]))
+      ψ_r = (isodd(j) & choi ? ψ_r = dag(ψ[j]) * dag(gate(x[j],s[j])) :
+                               ψ_r = dag(ψ[j]) * gate(x[j],s[j]))
       ψx = ψx * ψ_r
     end
     prob = abs2(ψx[])
@@ -717,8 +717,8 @@ function nll(L::LPDO{MPO}, data::Array; choi::Bool = false)
     # Project LPDO into the measurement eigenstates
     Φdag = dag(copy(lpdo))
     for j in 1:N
-      Φdag[j] = (isodd(j) & choi ? Φdag[j] = Φdag[j] * dag(state(x[j],s[j])) :
-                                   Φdag[j] = Φdag[j] * state(x[j],s[j]))
+      Φdag[j] = (isodd(j) & choi ? Φdag[j] = Φdag[j] * dag(gate(x[j],s[j])) :
+                                   Φdag[j] = Φdag[j] * gate(x[j],s[j]))
     end
     
     # Compute overlap

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -10,35 +10,32 @@ Save data and model on file:
   - `model`: (optional) MPS, MPO, or Choi
   - `output_path`: path to file
 """
-function writesamples(data::Matrix{Int64},
+function writesamples(data::Matrix{Int},
                       model::Union{MPS, MPO, LPDO, Choi},
                       output_path::String)
   # Make the path the file will sit in, if it doesn't exist
   mkpath(dirname(output_path))
   h5rewrite(output_path) do fout
-    #write(fout,"data",data)
     write(fout, "outcomes", data)
-    write(fout,"model",model)
+    write(fout,"model", model)
   end
 end
 
-function writesamples(data::Matrix{Pair{String, Int}},
+function writesamples(data::Matrix{Int},
                       output_path::String)
   # Make the path the file will sit in, if it doesn't exist
   mkpath(dirname(output_path))
   h5rewrite(output_path) do fout
-    #write(fout,"data",data)
-    write(fout, "bases", first.(data))
-    write(fout, "outcomes", last.(data))
+    write(fout, "outcomes", data)
   end
 end
+
 function writesamples(data::Matrix{Pair{String, Int}},
                       model::Union{MPS, MPO, LPDO, Choi},
                       output_path::String)
   # Make the path the file will sit in, if it doesn't exist
   mkpath(dirname(output_path))
   h5rewrite(output_path) do fout
-    #write(fout,"data",data)
     write(fout, "bases", first.(data))
     write(fout, "outcomes", last.(data))
     write(fout,"model",model)
@@ -50,33 +47,30 @@ function writesamples(data::Matrix{Pair{String, Int}},
   # Make the path the file will sit in, if it doesn't exist
   mkpath(dirname(output_path))
   h5rewrite(output_path) do fout
-    #write(fout,"data",data)
     write(fout, "bases", first.(data))
     write(fout, "outcomes", last.(data))
   end
 end
 
-function writesamples(data::Matrix{<: Pair},
+function writesamples(data::Matrix{Pair{String, Pair{String, Int}}},
                       model::Union{MPS, MPO, LPDO, Choi},
                       output_path::String)
   # Make the path the file will sit in, if it doesn't exist
   mkpath(dirname(output_path))
   h5rewrite(output_path) do fout
     write(fout, "inputs", first.(data))
-    #write(fout, "data_last", last.(data))
     write(fout, "bases", first.(last.(data)))
     write(fout, "outcomes", last.(last.(data)))
     write(fout, "model", model)
   end
 end
 
-function writesamples(data::Matrix{<: Pair},
+function writesamples(data::Matrix{Pair{String, Pair{String, Int}}},
                       output_path::String)
   # Make the path the file will sit in, if it doesn't exist
   mkpath(dirname(output_path))
   h5rewrite(output_path) do fout
     write(fout, "inputs", first.(data))
-    #write(fout, "data_last", last.(data))
     write(fout, "bases", first.(last.(data)))
     write(fout, "outcomes", last.(last.(data)))
   end
@@ -107,7 +101,6 @@ function readsamples(input_path::String)
   # Measurements in Z basis
   elseif exists(fin, "outcomes")
     data = read(fin,"outcomes")
-    #data = read(fin, "data")
   else
     close(fin)
     error("File must contain either \"data\" for quantum state tomography data or \"data_first\" and \"data_second\" for quantum process tomography.")
@@ -225,7 +218,7 @@ function convertdatapoint(outcome::Array{Int64}, basis::Array{String};
   @assert length(outcome) == length(basis)
   newdata = []
   if state
-    basis = "state" .* basis
+    basis = basis
   end
   for j in 1:length(outcome)
     if outcome[j] == 0 
@@ -273,14 +266,11 @@ end
 
 
 
-#function convertdatapoint(datapoint::Array{Pair{String,Int64}}; state::Bool=false)
+#function convertdatapoint(datapoint::Array{Pair{String,Int64}})
 #  newdata = []
 #  basis = first.(datapoint)
 #  outcome = last.(datapoint)
 #
-#  if state
-#    basis = "state" .* basis
-#  end
 #  for j in 1:length(datapoint)
 #    if outcome[j] == 0 
 #      push!(newdata, basis[j] * "+")
@@ -293,24 +283,20 @@ end
 #  return newdata
 #end
 
-#function convertdatapoints(datapoints::Matrix{Pair{String,Int64}}; state::Bool=false)
+#function convertdatapoints(datapoints::Matrix{Pair{String,Int64}})
 #  nshots = size(datapoints)[1]
 #  newdata = Matrix{String}(undef,nshots,size(datapoints)[2])
 #
 #  for n in 1:nshots
-#    newdata[n,:] = convertdatapoint(datapoints[n,:]; state = state)
+#    newdata[n,:] = convertdatapoint(datapoints[n,:])
 #  end
 #  return newdata
 #end
 
 
 
-#function convertdatapoint(datapoint::Array{Int64}, basis::Array{String};
-#                          state::Bool=false)
+#function convertdatapoint(datapoint::Array{Int64}, basis::Array{String})
 #  newdata = []
-#  if state
-#    basis = "state" .* basis
-#  end
 #  for j in 1:length(datapoint)
 #    push!(newdata,basis[j] => datapoint[j])
 #  end

--- a/test/circuitops.jl
+++ b/test/circuitops.jl
@@ -324,131 +324,65 @@ end
 end
 
 
-@testset "apply gate: prep X+" begin
-  psi = qubits(1)
-  PastaQ.applygate!(psi,"prepX+",1)
+@testset "apply gate: prep X+/X-" begin
+  psi = qubits(1, ["X+"])
   @test PastaQ.fullvector(psi) ≈ 1/sqrt(2.)*[1.,1.]
   
-  psi = qubits(1)
-  gate_data = ("prepX+", 1)
-  g = gate(psi,gate_data)
-  PastaQ.applygate!(psi,g)
-  @test PastaQ.fullvector(psi) ≈ 1/sqrt(2.)*[1.,1.]
-end
-
-
-@testset "apply gate: prep X-" begin
-  psi = qubits(1)
-  PastaQ.applygate!(psi,"prepX-",1)
-  @test PastaQ.fullvector(psi) ≈ 1/sqrt(2.)*[1.,-1.]
-  
-  psi = qubits(1)
-  gate_data = ("prepX-", 1)
-  g = gate(psi,gate_data)
-  PastaQ.applygate!(psi,g)
+  psi = qubits(1, ["X-"])
   @test PastaQ.fullvector(psi) ≈ 1/sqrt(2.)*[1.,-1.]
 end
 
-@testset "apply gate: prep Y+" begin
-  psi = qubits(1)
-  PastaQ.applygate!(psi,"prepY+",1)
+@testset "apply gate: prep Y+/Y-" begin
+  psi = qubits(1, ["Y+"])
   @test PastaQ.fullvector(psi) ≈ 1/sqrt(2.)*[1.,im]
   
-  psi = qubits(1)
-  gate_data = ("prepY+", 1)
-  g = gate(psi,gate_data)
-  PastaQ.applygate!(psi,g)
-  @test PastaQ.fullvector(psi) ≈ 1/sqrt(2.)*[1.,im]
-end
-
-
-@testset "apply gate: prep Y-" begin
-  psi = qubits(1)
-  PastaQ.applygate!(psi,"prepY-",1)
-  @test PastaQ.fullvector(psi) ≈ 1/sqrt(2.)*[1.,-im]
-  
-  psi = qubits(1)
-  gate_data = ("prepY-", 1)
-  g = gate(psi,gate_data)
-  PastaQ.applygate!(psi,g)
+  psi = qubits(1, ["Y-"])
   @test PastaQ.fullvector(psi) ≈ 1/sqrt(2.)*[1.,-im]
 end
 
-@testset "apply gate: prep Z+" begin
-  psi = qubits(1)
-  PastaQ.applygate!(psi,"prepZ+",1)
+@testset "apply gate: prep Z+/Z-" begin
+  psi = qubits(1, ["Z+"])
   @test PastaQ.fullvector(psi) ≈ [1.,0.]
   
-  psi = qubits(1)
-  gate_data = ("prepZ+", 1)
-  g = gate(psi,gate_data)
-  PastaQ.applygate!(psi,g)
-  @test PastaQ.fullvector(psi) ≈ [1.,0.]
-end
-
-@testset "apply gate: prep Z-" begin
-  psi = qubits(1)
-  PastaQ.applygate!(psi,"prepZ-",1)
-  @test PastaQ.fullvector(psi) ≈ [0.,1.]
-  
-  psi = qubits(1)
-  gate_data = ("prepZ-", 1)
-  g = gate(psi,gate_data)
-  PastaQ.applygate!(psi,g)
+  psi = qubits(1, ["Z-"])
   @test PastaQ.fullvector(psi) ≈ [0.,1.]
 end
 
 @testset "apply gate: meas X" begin
-  psi = qubits(1)
-  PastaQ.applygate!(psi,"prepX+",1)
-  PastaQ.applygate!(psi,"measX",1)
+  psi = qubits(1, ["X+"])
+  PastaQ.applygate!(psi,"basisX",1; dag = true)
   @test PastaQ.fullvector(psi) ≈ [1.,0.]
-  psi = qubits(1)
-  PastaQ.applygate!(psi,"prepX-",1)
-  PastaQ.applygate!(psi,"measX",1)
+  psi = qubits(1, ["X-"])
+  PastaQ.applygate!(psi,"basisX",1; dag = true)
   @test PastaQ.fullvector(psi) ≈ [0.,1.]
 
-  psi = qubits(1)
-  gate_data = ("prepX+", 1)
-  g = gate(psi,gate_data)
-  PastaQ.applygate!(psi,g)
-  gate_data = ("measX", 1)
+  psi = qubits(1, ["X+"])
+  gate_data = ("basisX", 1, (dag = true,))
   g = gate(psi,gate_data)
   PastaQ.applygate!(psi,g)
   @test PastaQ.fullvector(psi) ≈ [1.,0.]
-  psi = qubits(1)
-  gate_data = ("prepX-", 1)
-  g = gate(psi,gate_data)
-  PastaQ.applygate!(psi,g)
-  gate_data = ("measX", 1)
+  psi = qubits(1, ["X-"])
+  gate_data = ("basisX", 1, (dag = true,))
   g = gate(psi,gate_data)
   PastaQ.applygate!(psi,g)
   @test PastaQ.fullvector(psi) ≈ [0.,1.]
 end
 
 @testset "apply gate: meas Y" begin
-  psi = qubits(1)
-  PastaQ.applygate!(psi,"prepY+",1)
-  PastaQ.applygate!(psi,"measY",1)
+  psi = qubits(1, ["Y+"])
+  PastaQ.applygate!(psi,"basisY",1; dag = true)
   @test PastaQ.fullvector(psi) ≈ [1.,0.]
-  psi = qubits(1)
-  PastaQ.applygate!(psi,"prepY-",1)
-  PastaQ.applygate!(psi,"measY",1)
+  psi = qubits(1, ["Y-"])
+  PastaQ.applygate!(psi,"basisY",1; dag = true)
   @test PastaQ.fullvector(psi) ≈ [0.,1.]
 
-  psi = qubits(1)
-  gate_data = ("prepY+", 1)
-  g = gate(psi,gate_data)
-  PastaQ.applygate!(psi,g)
-  gate_data = ("measY", 1)
+  psi = qubits(1, ["Y+"])
+  gate_data = ("basisY", 1, (dag = true,))
   g = gate(psi,gate_data)
   PastaQ.applygate!(psi,g)
   @test PastaQ.fullvector(psi) ≈ [1.,0.]
-  psi = qubits(1)
-  gate_data = ("prepY-", 1)
-  g = gate(psi,gate_data)
-  PastaQ.applygate!(psi,g)
-  gate_data = ("measY", 1)
+  psi = qubits(1, ["Y-"])
+  gate_data = ("basisY", 1, (dag = true,))
   g = gate(psi,gate_data)
   PastaQ.applygate!(psi,g)
   @test PastaQ.fullvector(psi) ≈ [0.,1.]
@@ -456,23 +390,19 @@ end
 
 @testset "apply gate: meas Z" begin
   psi = qubits(1)
-  PastaQ.applygate!(psi,"measZ",1)
+  PastaQ.applygate!(psi,"basisZ",1; dag = true)
   @test PastaQ.fullvector(psi) ≈ [1.,0.]
-  psi = qubits(1)
-  PastaQ.applygate!(psi,"prepZ-",1)
-  PastaQ.applygate!(psi,"measZ",1)
+  psi = qubits(1, ["Z-"])
+  PastaQ.applygate!(psi,"basisZ",1; dag = true)
   @test PastaQ.fullvector(psi) ≈ [0.,1.]
 
   psi = qubits(1)
-  gate_data = ("measZ", 1)
+  gate_data = ("basisZ", 1, (dag = true,))
   g = gate(psi,gate_data)
   PastaQ.applygate!(psi,g)
   @test PastaQ.fullvector(psi) ≈ [1.,0.]
-  psi = qubits(1)
-  gate_data = ("prepZ-", 1)
-  g = gate(psi,gate_data)
-  PastaQ.applygate!(psi,g)
-  gate_data = ("measZ", 1)
+  psi = qubits(1, ["Z-"])
+  gate_data = ("basisZ", 1, (dag = true,))
   g = gate(psi,gate_data)
   PastaQ.applygate!(psi,g)
   @test PastaQ.fullvector(psi) ≈ [0.,1.]

--- a/test/datagen.jl
+++ b/test/datagen.jl
@@ -160,9 +160,9 @@ end
       end
     end
   
-    ψ2 = ψ_out[1] * dag(initstate(x2[1],s[1]))
+    ψ2 = ψ_out[1] * dag(inputstate(x2[1],s[1]))
     for j in 2:N
-      ψ_r = ψ_out[j] * dag(initstate(x2[j],s[j]))
+      ψ_r = ψ_out[j] * dag(inputstate(x2[j],s[j]))
       ψ2 = ψ2 * ψ_r
     end
     ψ2 = ψ2[]
@@ -192,9 +192,9 @@ end
       ψ1 = (ψ1 * noprime!(ψ_r) * setelt(s[N]=>x1[N]))[]
     end
   
-    ψ2 = dag(ψ_out[1]) * initstate(x2[1],s[1])
+    ψ2 = dag(ψ_out[1]) * inputstate(x2[1],s[1])
     for j in 2:N
-      ψ_r = dag(ψ_out[j]) * initstate(x2[j],s[j])
+      ψ_r = dag(ψ_out[j]) * inputstate(x2[j],s[j])
       ψ2 = ψ2 * ψ_r
     end
     ψ2 = ψ2[]

--- a/test/datagen.jl
+++ b/test/datagen.jl
@@ -268,11 +268,11 @@ end
   @test size(data) == (nshots,N)
   
   # 2a) Generate data with a MPS on multiple bases
-  bases = randombases(N,nshots;localbasis=["X","Y","Z"])
+  bases = randombases(N,nshots;local_basis=["X","Y","Z"])
   data = getsamples(ψ,bases)
   @test size(data) == (nshots,N)
   # 2b) Generate data with a MPO on multiple bases
-  bases = randombases(N,nshots;localbasis=["X","Y","Z"])
+  bases = randombases(N,nshots;local_basis=["X","Y","Z"])
   data = getsamples(ρ,bases)
   @test size(data) == (nshots,N)
 
@@ -282,18 +282,18 @@ end
   data, _ = getsamples(N, gates, nshots;
                        noise = ("amplitude_damping", (γ = 0.1,)))
   @test size(data) == (nshots, N)
-  data, _ = getsamples(N, gates, nshots; localbasis = ["X","Y","Z"])
+  data, _ = getsamples(N, gates, nshots; local_basis = ["X","Y","Z"])
   @test size(data) == (nshots,N)
   data, _ = getsamples(N, gates, nshots;
                        noise = ("amplitude_damping", (γ = 0.1,)),
-                       localbasis = ["X","Y","Z"])
+                       local_basis = ["X","Y","Z"])
   @test size(data) == (nshots,N)
   data, M = getsamples(N, gates, nshots;)
   data, M = getsamples(N, gates, nshots; noise = ("amplitude_damping", (γ = 0.1,)))
-  data, M = getsamples(N, gates, nshots; localbasis = ["X","Y","Z"])
+  data, M = getsamples(N, gates, nshots; local_basis = ["X","Y","Z"])
   data, M = getsamples(N, gates, nshots;
                        noise = ("amplitude_damping", (γ = 0.1,)),
-                       localbasis = ["X","Y","Z"])
+                       local_basis = ["X","Y","Z"])
   
   # 4) Process tomography
   data = getsamples(N, gates, nshots; process = true, build_process = false)
@@ -331,11 +331,11 @@ end
   @test size(data) == (nshots,N)
   
   # 2a) Generate data with a MPS on multiple bases
-  bases = randombases(N,nshots;localbasis=["X","Y","Z"])
+  bases = randombases(N,nshots;local_basis=["X","Y","Z"])
   data = getsamples(ψ,bases;readout_errors = readout_errors)
   @test size(data) == (nshots,N)
   # 2b) Generate data with a MPO on multiple bases
-  bases = randombases(N,nshots;localbasis=["X","Y","Z"])
+  bases = randombases(N,nshots;local_basis=["X","Y","Z"])
   data = getsamples(ρ,bases;readout_errors = readout_errors)
   @test size(data) == (nshots,N)
 
@@ -346,20 +346,20 @@ end
                        noise = ("amplitude_damping", (γ = 0.1,)),
                        readout_errors = readout_errors)
   @test size(data) == (nshots,N)
-  data, _ = getsamples(N, gates, nshots; localbasis = ["X","Y","Z"], readout_errors = readout_errors)
+  data, _ = getsamples(N, gates, nshots; local_basis = ["X","Y","Z"], readout_errors = readout_errors)
   @test size(data) == (nshots,N)
   data, _ = getsamples(N, gates, nshots;
                        noise = ("amplitude_damping", (γ = 0.1,)),
-                       localbasis = ["X","Y","Z"],
+                       local_basis = ["X","Y","Z"],
                        readout_errors = readout_errors)
   @test size(data) == (nshots,N)
   data, M = getsamples(N, gates, nshots; readout_errors = readout_errors)
   data, M = getsamples(N, gates, nshots;
                        noise = ("amplitude_damping", (γ = 0.1,)), readout_errors = readout_errors)
-  data, M = getsamples(N, gates, nshots; localbasis = ["X","Y","Z"], readout_errors = readout_errors)
+  data, M = getsamples(N, gates, nshots; local_basis = ["X","Y","Z"], readout_errors = readout_errors)
   data, M = getsamples(N, gates, nshots;
                        noise = ("amplitude_damping", (γ=0.1,)),
-                       localbasis = ["X","Y","Z"],
+                       local_basis = ["X","Y","Z"],
                        readout_errors = readout_errors)
   
   # 4) Process tomography

--- a/test/datagen.jl
+++ b/test/datagen.jl
@@ -115,7 +115,7 @@ end
     if (basis[1] == "Z")
       ψ1 = ψ_out[1] * setelt(s[1]=>x1[1])
     else
-      rotation = gate(ψ_out,"meas$(basis[1])",1)
+      rotation = gate(ψ_out,"basis$(basis[1])",1; dag = true)
       ψ_r = ψ_out[1] * rotation
       ψ1 = noprime!(ψ_r) * setelt(s[1]=>x1[1])
     end
@@ -123,7 +123,7 @@ end
       if (basis[j] == "Z")
         ψ1 = ψ1 * ψ_out[j] * setelt(s[j]=>x1[j])
       else
-        rotation = gate(ψ_out,"meas$(basis[j])",j)
+        rotation = gate(ψ_out,"basis$(basis[j])",j; dag = true)
         ψ_r = ψ_out[j] * rotation
         ψ1 = ψ1 * noprime!(ψ_r) * setelt(s[j]=>x1[j])
       end
@@ -131,7 +131,7 @@ end
     if (basis[N] == "Z")
       ψ1 = (ψ1 * ψ_out[N] * setelt(s[N]=>x1[N]))[]
     else
-      rotation = gate(ψ_out,"meas$(basis[N])",N)
+      rotation = gate(ψ_out,"basis$(basis[N])",N, dag = true)
       ψ_r = ψ_out[N] * rotation
       ψ1 = (ψ1 * noprime!(ψ_r) * setelt(s[N]=>x1[N]))[]
     end
@@ -141,28 +141,28 @@ end
     for j in 1:N
       if basis[j] == "X"
         if x1[j] == 1
-          push!(x2,"stateX+")
+          push!(x2,"X+")
         else
-          push!(x2,"stateX-")
+          push!(x2,"X-")
         end
       elseif basis[j] == "Y"
         if x1[j] == 1
-          push!(x2,"stateY+")
+          push!(x2,"Y+")
         else
-          push!(x2,"stateY-")
+          push!(x2,"Y-")
         end
       elseif basis[j] == "Z"
         if x1[j] == 1
-          push!(x2,"stateZ+")
+          push!(x2,"Z+")
         else
-          push!(x2,"stateZ-")
+          push!(x2,"Z-")
         end
       end
     end
   
-    ψ2 = ψ_out[1] * dag(gate(x2[1],s[1]))
+    ψ2 = ψ_out[1] * dag(initstate(x2[1],s[1]))
     for j in 2:N
-      ψ_r = ψ_out[j] * dag(gate(x2[j],s[j]))
+      ψ_r = ψ_out[j] * dag(initstate(x2[j],s[j]))
       ψ2 = ψ2 * ψ_r
     end
     ψ2 = ψ2[]
@@ -171,7 +171,7 @@ end
     if (basis[1] == "Z")
       ψ1 = dag(ψ_out[1]) * setelt(s[1]=>x1[1])
     else
-      rotation = gate(ψ_out,"meas$(basis[1])",1)
+      rotation = gate(ψ_out,"basis$(basis[1])",1; dag = true)
       ψ_r = dag(ψ_out[1]) * dag(rotation)
       ψ1 = noprime!(ψ_r) * setelt(s[1]=>x1[1])
     end
@@ -179,7 +179,7 @@ end
       if (basis[j] == "Z")
         ψ1 = ψ1 * dag(ψ_out[j]) * setelt(s[j]=>x1[j])
       else
-        rotation = gate(ψ_out,"meas$(basis[j])",j)
+        rotation = gate(ψ_out,"basis$(basis[j])",j; dag = true)
         ψ_r = dag(ψ_out[j]) * dag(rotation)
         ψ1 = ψ1 * noprime!(ψ_r) * setelt(s[j]=>x1[j])
       end
@@ -187,14 +187,14 @@ end
     if (basis[N] == "Z")
       ψ1 = (ψ1 * dag(ψ_out[N]) * setelt(s[N]=>x1[N]))[]
     else
-      rotation = gate(ψ_out,"meas$(basis[N])",N)
+      rotation = gate(ψ_out,"basis$(basis[N])",N; dag = true)
       ψ_r = dag(ψ_out[N]) * dag(rotation)
       ψ1 = (ψ1 * noprime!(ψ_r) * setelt(s[N]=>x1[N]))[]
     end
   
-    ψ2 = dag(ψ_out[1]) * gate(x2[1],s[1])
+    ψ2 = dag(ψ_out[1]) * initstate(x2[1],s[1])
     for j in 2:N
-      ψ_r = dag(ψ_out[j]) * gate(x2[j],s[j])
+      ψ_r = dag(ψ_out[j]) * initstate(x2[j],s[j])
       ψ2 = ψ2 * ψ_r
     end
     ψ2 = ψ2[]
@@ -214,9 +214,8 @@ end
   preps = PastaQ.randompreparations(N,ntrial)
   
   for n in 1:ntrial
-    pgates = PastaQ.preparationgates(preps[n,:])
     mgates = PastaQ.measurementgates(bases[n,:])
-    ψ_in  = runcircuit(N,pgates)
+    ψ_in  = qubits(N, preps[n,:])
     ψ_out = runcircuit(ψ_in,gates)
     
     Ψ_out = PastaQ.projectunitary(U,preps[n,:])
@@ -240,9 +239,8 @@ end
   bases = randombases(N,ntrial)
   preps = PastaQ.randompreparations(N,ntrial)
   for n in 1:ntrial
-    pgates = PastaQ.preparationgates(preps[n,:])
     mgates = PastaQ.measurementgates(bases[n,:])
-    ψ_in  = runcircuit(N,pgates)
+    ψ_in  = qubits(N, preps[n,:])
     ρ_out = runcircuit(ψ_in, gates; noise = ("amplitude_damping", (γ = 0.1,)))
     
     Λ_out = PastaQ.projectchoi(Λ,preps[n,:])

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -16,10 +16,10 @@ U = runcircuit(N, gates; process = true)
 Random.seed!(1234)
 nshots = 100
 
-data, ψ = getsamples(N, gates, nshots; localbasis = ["X","Y","Z"])
+data, ψ = getsamples(N, gates, nshots)
 writesamples(data, ψ, "../examples/data/qst_circuit_test.h5")
 
-data, ρ = getsamples(N, gates, nshots; localbasis = ["X","Y","Z"],
+data, ρ = getsamples(N, gates, nshots,
                      noise = ("amplitude_damping", (γ = 0.01,)))
 writesamples(data, ρ, "../examples/data/qst_circuit_noisy_test.h5")
 

--- a/test/gates.jl
+++ b/test/gates.jl
@@ -51,22 +51,22 @@ using LinearAlgebra
   ggdag = g * prime(dag(g),plev=1,1)
   @test array(ggdag) ≈ Matrix{Int}(I, 2, 2)
    
-  g = state("X+",i) 
+  g = initstate("X+",i) 
   @test plev(ind(g, 1)) == 0
   
-  g = state("X-",i) 
+  g = initstate("X-",i) 
   @test plev(ind(g, 1)) == 0
   
-  g = state("Y+",i) 
+  g = initstate("Y+",i) 
   @test plev(ind(g, 1)) == 0
   
-  g = state("Y-",i) 
+  g = initstate("Y-",i) 
   @test plev(ind(g, 1)) == 0
   
-  g = state("Z+",i) 
+  g = initstate("Z+",i) 
   @test plev(ind(g, 1)) == 0
 
-  g = state("Z-",i) 
+  g = initstate("Z-",i) 
   @test plev(ind(g, 1)) == 0 
   
   θ = π * rand()

--- a/test/gates.jl
+++ b/test/gates.jl
@@ -51,22 +51,22 @@ using LinearAlgebra
   ggdag = g * prime(dag(g),plev=1,1)
   @test array(ggdag) ≈ Matrix{Int}(I, 2, 2)
    
-  g = initstate("X+",i) 
+  g = inputstate("X+",i) 
   @test plev(ind(g, 1)) == 0
   
-  g = initstate("X-",i) 
+  g = inputstate("X-",i) 
   @test plev(ind(g, 1)) == 0
   
-  g = initstate("Y+",i) 
+  g = inputstate("Y+",i) 
   @test plev(ind(g, 1)) == 0
   
-  g = initstate("Y-",i) 
+  g = inputstate("Y-",i) 
   @test plev(ind(g, 1)) == 0
   
-  g = initstate("Z+",i) 
+  g = inputstate("Z+",i) 
   @test plev(ind(g, 1)) == 0
 
-  g = initstate("Z-",i) 
+  g = inputstate("Z-",i) 
   @test plev(ind(g, 1)) == 0 
   
   θ = π * rand()

--- a/test/gates.jl
+++ b/test/gates.jl
@@ -51,59 +51,23 @@ using LinearAlgebra
   ggdag = g * prime(dag(g),plev=1,1)
   @test array(ggdag) ≈ Matrix{Int}(I, 2, 2)
    
-  g = gate("prepX+",i) 
-  @test plev(inds(g)[1]) == 1 
-  @test plev(inds(g)[2]) == 0 
-  ggdag = g * prime(dag(g),plev=1,1)
-  @test array(ggdag) ≈ Matrix{Int}(I, 2, 2)
+  g = state("X+",i) 
+  @test plev(ind(g, 1)) == 0
   
-  g = gate("prepX-",i) 
-  @test plev(inds(g)[1]) == 1 
-  @test plev(inds(g)[2]) == 0 
-  ggdag = g * prime(dag(g),plev=1,1)
-  @test array(ggdag) ≈ Matrix{Int}(I, 2, 2)
+  g = state("X-",i) 
+  @test plev(ind(g, 1)) == 0
   
-  g = gate("prepY+",i) 
-  @test plev(inds(g)[1]) == 1 
-  @test plev(inds(g)[2]) == 0 
-  ggdag = g * prime(dag(g),plev=1,1)
-  @test array(ggdag) ≈ Matrix{Int}(I, 2, 2)
+  g = state("Y+",i) 
+  @test plev(ind(g, 1)) == 0
   
-  g = gate("prepY-",i) 
-  @test plev(inds(g)[1]) == 1 
-  @test plev(inds(g)[2]) == 0 
-  ggdag = g * prime(dag(g),plev=1,1)
-  @test array(ggdag) ≈ Matrix{Int}(I, 2, 2)
+  g = state("Y-",i) 
+  @test plev(ind(g, 1)) == 0
   
-  g = gate("prepZ+",i) 
-  @test plev(inds(g)[1]) == 1 
-  @test plev(inds(g)[2]) == 0 
-  ggdag = g * prime(dag(g),plev=1,1)
-  @test array(ggdag) ≈ Matrix{Int}(I, 2, 2)
-  
-  g = gate("prepZ-",i) 
-  @test plev(inds(g)[1]) == 1 
-  @test plev(inds(g)[2]) == 0 
-  ggdag = g * prime(dag(g),plev=1,1)
-  @test array(ggdag) ≈ Matrix{Int}(I, 2, 2)
-  
-  g = gate("measX",i) 
-  @test plev(inds(g)[1]) == 1 
-  @test plev(inds(g)[2]) == 0 
-  ggdag = g * prime(dag(g),plev=1,1)
-  @test array(ggdag) ≈ Matrix{Int}(I, 2, 2)
-  
-  g = gate("measY",i) 
-  @test plev(inds(g)[1]) == 1 
-  @test plev(inds(g)[2]) == 0 
-  ggdag = g * prime(dag(g),plev=1,1)
-  @test array(ggdag) ≈ Matrix{Int}(I, 2, 2)
-  
-  g = gate("measZ",i) 
-  @test plev(inds(g)[1]) == 1 
-  @test plev(inds(g)[2]) == 0 
-  ggdag = g * prime(dag(g),plev=1,1)
-  @test array(ggdag) ≈ Matrix{Int}(I, 2, 2)
+  g = state("Z+",i) 
+  @test plev(ind(g, 1)) == 0
+
+  g = state("Z-",i) 
+  @test plev(ind(g, 1)) == 0 
   
   θ = π * rand()
   g = gate("Rx",i,θ=θ)

--- a/test/randomstates.jl
+++ b/test/randomstates.jl
@@ -9,21 +9,21 @@ using Random
   χ = 3
   
   # Real-valued with randpars
-  ψ = randomstate(N;χ=χ,complex=false)
+  ψ = randomstate(Float64, N; χ = χ)
   @test length(ψ) == N
   @test maxlinkdim(ψ) == χ 
   for j in 1:length(ψ)
     @test eltype(ψ[j]) == Float64
   end
   # Real-valued with circuit
-  ψ = randomstate(N;χ=χ,init="circuit",complex=false)
+  ψ = randomstate(Float64, N; χ = χ, alg = "circuit")
   @test length(ψ) == N
   @test maxlinkdim(ψ) == χ 
   for j in 1:length(ψ)
     @test eltype(ψ[j]) == Float64
   end
   # Complex-valued with randpars
-  ψ = randomstate(N;χ=χ,complex=true)
+  ψ = randomstate(N; χ = χ)
   @test length(ψ) == N
   @test maxlinkdim(ψ) == χ 
   for j in 1:length(ψ)
@@ -33,11 +33,12 @@ using Random
   # TODO: complex-valued with circuit: not implemented
 
   # Normalization
-  ψ = randomstate(N;χ=χ,normalize=true,complex=false)
+  ψ = randomstate(Float64, N; χ = χ, normalize = true)
   @test norm(ψ)^2 ≈ 1
-  ψ = randomstate(N;χ=χ,init="circuit",normalize=true,complex=false)
+  ψ = randomstate(Float64, N; χ = χ, alg = "circuit",
+                  normalize = true)
   @test norm(ψ)^2 ≈ 1
-  ψ = randomstate(N;χ=χ,complex=true,normalize=true)
+  ψ = randomstate(N; χ = χ, normalize = true)
   @test norm(ψ)^2 ≈ 1
   
 end
@@ -48,7 +49,7 @@ end
   ξ = 2
   
   # Real-valued with randpars
-  ρ = randomstate(N;χ=χ,ξ=ξ,mixed=true,complex=false)
+  ρ = randomstate(Float64, N; χ = χ, ξ = ξ, mixed = true)
   @test length(ρ) == N
   @test maxlinkdim(ρ.X) == χ 
   for j in 1:length(ρ)
@@ -58,7 +59,7 @@ end
   @test sum(abs.(imag(diag(ρ_mat)))) ≈ 0.0 atol=1e-10
   @test all(real(eigvals(ρ_mat)) .≥ 0) 
   # Complex-valued with randpars
-  ρ = randomstate(N;χ=χ,ξ=ξ,mixed=true,complex=true)
+  ρ = randomstate(N; χ = χ, ξ = ξ, mixed = true)
   @test length(ρ) == N
   @test maxlinkdim(ρ.X) == χ 
   for j in 1:length(ρ)
@@ -71,9 +72,9 @@ end
   # TODO: randomLPDO with circuit + thermal state not implemented
 
   # Normalization
-  ρ = randomstate(N;χ=χ,normalize=true,mixed=true,complex=false)
+  ρ = randomstate(Float64, N; χ = χ, normalize = true, mixed = true)
   @test tr(ρ) ≈ 1
-  ρ = randomstate(N;χ=χ,complex=true,normalize=true,mixed=true)
+  ρ = randomstate(N; χ = χ, normalize = true, mixed = true)
   @test tr(ρ) ≈ 1
   
 end
@@ -84,14 +85,14 @@ end
   χ = 3
   
   # Real-valued with randpars
-  ρ = randomprocess(N;χ=χ,mixed=false,complex=false)
+  ρ = randomprocess(Float64, N; χ = χ, mixed = false)
   @test length(ρ) == N
   @test maxlinkdim(ρ) == χ 
   for j in 1:length(ρ)
     @test eltype(ρ[j]) == Float64
   end
   # Complex-valued with randpars
-  ρ = randomstate(N;χ=χ,mixed=false,complex=true)
+  ρ = randomstate(N; χ = χ, mixed = false)
   @test length(ρ) == N
   @test maxlinkdim(ρ) == χ 
   for j in 1:length(ρ)
@@ -107,7 +108,7 @@ end
   ξ = 2
   
   # Real-valued with randpars
-  Λ = randomprocess(N;χ=χ,ξ=ξ,mixed=true,complex=false)
+  Λ = randomprocess(Float64, N; χ = χ, ξ = ξ, mixed = true)
   ρ = Λ.M
   @test length(ρ) == N
   @test maxlinkdim(ρ.X) == χ 
@@ -115,7 +116,7 @@ end
     @test eltype(ρ.X[j]) == Float64
   end
   # Complex-valued with randpars
-  Λ = randomprocess(N;χ=χ,ξ=ξ,mixed=true,complex=true)
+  Λ = randomprocess(N; χ = χ, ξ = ξ, mixed = true)
   ρ = Λ.M
   @test length(ρ) == N
   @test maxlinkdim(ρ.X) == χ 


### PR DESCRIPTION
This makes the following changes:
- Remove the requirement to implement `"meas[...]"` gates. Instead, they are renamed `"basis[...]"` gates, and defined automatically using a Hermitian eigendecomposition (so when `gate("basisX")` is called, an eigendecomposition of `gate("X")` is performed by default, but a user can overload  `gate("basisX")` if they want).
- Replace `"prepX+"` gates with a new `inputstate("X+")` interface. 
- New interface `qubits(N, ["X+", "Y-", "Z+"])` for making a product state in an arbitrary basis. The function uses the new `inputstate` definitions, such as `inputstate("X+")`. 
- Change the `randomstate`/`randomprocess` insterface for selecting the element type. This remove the `complex` keyword argument. Instead, the element type is passed explicitly as the first argument, i.e. `randomstate(Float64, 4)`. By default, `randomstate(4) = randomstate(ComplexF64, 4)`, as before.
- Rename the `randomstate`/`randomprocess` keyword argument `init` to `alg` for choosing the algorithm for generating the random tensors (which right now are `"rand"` or `"circuit"`).
- Change `randomstate`/`randomprocess` to default to having dimension 1 links and purified indices.
- Rename `getsamples` keyword argument `inputstates` to `local_inputstate` and `localbasis` to `local_basis`.
- In `getsamples`, always sample from a random Pauli basis `["X", "Y", "Z"]` by default.

This closes #127, #128, and #135.