### PR TITLE
Fix normalize!(::MPO) and tr(::MPO)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,6 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 HDF5 = "0.13.1"
-ITensors = "0.1.23"
+ITensors = "0.1.24"
 JLD = "0.10.0"
 julia = "1.4"

--- a/src/choi.jl
+++ b/src/choi.jl
@@ -3,24 +3,33 @@ struct Choi{MT <: Union{MPO, LPDO}}
   M::MT
 end
 
-Base.length(C::Choi) = length(C.M)
+Base.length(Λ::Choi) = length(Λ.M)
 
-Base.copy(C::Choi) = Choi(copy(C.M))
+Base.copy(Λ::Choi) = Choi(copy(Λ.M))
 
-function Base.getindex(C::Choi, args...)
-  error("getindex(C::Choi, args...) is purposefully not implemented yet.")
+function Base.getindex(Λ::Choi, args...)
+  error("getindex(Λ::Choi, args...) is purposefully not implemented yet.")
 end
 
-function Base.setindex!(C::Choi, args...)
-  error("setindex!(C::Choi, args...) is purposefully not implemented yet.")
+function Base.setindex!(Λ::Choi, args...)
+  error("setindex!(Λ::Choi, args...) is purposefully not implemented yet.")
 end
+
+#
+# Linear algebra/distance measures
+#
+
+tr(Λ::Choi; kwargs...) = tr(Λ.M; kwargs...)
+
+fidelity_bound(Λ1::Choi, Λ2::Choi) =
+  fidelity_bound(Λ1.M, Λ2.M)
 
 function HDF5.write(parent::Union{HDF5File,HDF5Group},
                     name::AbstractString,
-                    C::Choi)
+                    Λ::Choi)
   g = g_create(parent, name)
-  attrs(g)["type"] = String(Symbol(typeof(C)))
-  write(g, "M", C.M)
+  attrs(g)["type"] = String(Symbol(typeof(Λ)))
+  write(g, "M", Λ.M)
 end
 
 function HDF5.read(parent::Union{HDF5File, HDF5Group},

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -2,3 +2,8 @@ import ITensors:
   # circuits/gates.jl
   space,
   state
+
+import LinearAlgebra:
+  normalize!,
+  tr
+

--- a/src/lpdo.jl
+++ b/src/lpdo.jl
@@ -30,7 +30,7 @@ ket(L::LPDO, j::Int) = prime(L.X[j], !purifier_tag(L))
 bra(L::LPDO) = dag(L.X)
 bra(L::LPDO, j::Int) = dag(L.X[j])
 
-LinearAlgebra.tr(L::LPDO) = inner(L.X, L.X)
+tr(L::LPDO) = inner(L.X, L.X)
 
 logtr(L::LPDO) = loginner(L.X, L.X)
 
@@ -51,10 +51,10 @@ An LPDO `L = X X†` is normalized by `tr(L) = tr(X X†)`, so each `X` is norma
 
 Passing a vector `v` as the keyword arguments `localnorms!` (`sqrt_localnorms!`) will fill the vector with the (square root) of the normalization factor per site. For an MPS `ψ`, `prod(v) ≈ norm(ψ)`. For an MPO `M`, `prod(v) ≈ tr(M). For an LPDO `L`, `prod(v)^2 ≈ tr(L)`.
 """
-function LinearAlgebra.normalize!(M::MPO;
-                                  plev = 0 => 1,
-                                  tags = ts"" => ts"",
-                                  localnorms! = [])
+function normalize!(M::MPO;
+                    plev = 0 => 1,
+                    tags = ts"" => ts"",
+                    localnorms! = [])
   N = length(M)
   resize!(localnorms!, N)
   blob = tr(M[1]; plev = plev, tags = tags)
@@ -77,7 +77,7 @@ function LinearAlgebra.normalize!(M::MPO;
   return M
 end
 
-function LinearAlgebra.normalize!(L::LPDO; sqrt_localnorms! = [])
+function normalize!(L::LPDO; sqrt_localnorms! = [])
   N = length(L)
   resize!(sqrt_localnorms!, N)
   # TODO: replace with:
@@ -107,7 +107,7 @@ function LinearAlgebra.normalize!(L::LPDO; sqrt_localnorms! = [])
   return L
 end
 
-function LinearAlgebra.normalize!(ψ::MPS; localnorms! = [])
+function normalize!(ψ::MPS; localnorms! = [])
   normalize!(LPDO(ψ); sqrt_localnorms! = localnorms!)
   return ψ
 end

--- a/src/lpdo.jl
+++ b/src/lpdo.jl
@@ -51,23 +51,27 @@ An LPDO `L = X X†` is normalized by `tr(L) = tr(X X†)`, so each `X` is norma
 
 Passing a vector `v` as the keyword arguments `localnorms!` (`sqrt_localnorms!`) will fill the vector with the (square root) of the normalization factor per site. For an MPS `ψ`, `prod(v) ≈ norm(ψ)`. For an MPO `M`, `prod(v) ≈ tr(M). For an LPDO `L`, `prod(v)^2 ≈ tr(L)`.
 """
-function LinearAlgebra.normalize!(M::MPO; localnorms! = [])
+function LinearAlgebra.normalize!(M::MPO;
+                                  plev = 0 => 1,
+                                  tags = ts"" => ts"",
+                                  localnorms! = [])
   N = length(M)
   resize!(localnorms!, N)
-  blob = M[1] * δ(dag(siteinds(M, 1)))
+  blob = tr(M[1]; plev = plev, tags = tags)
   localZ = norm(blob)
   blob /= localZ
   M[1] /= localZ
   localnorms![1] = localZ
   for j in 2:N-1
-    blob *= (M[j] * δ(dag(siteinds(M, j))))
+    blob *= M[j]
+    blob = tr(blob; plev = plev, tags = tags)
     localZ = norm(blob)
     blob /= localZ
     M[j] /= localZ
     localnorms![j] = localZ
   end
-  blob *= (M[N] * δ(dag(siteinds(M, N))))
-  localZ = blob[]
+  blob *= M[N]
+  localZ = tr(blob; plev = plev, tags = tags)
   M[N] /= localZ
   localnorms![N] = localZ
   return M
@@ -77,7 +81,7 @@ function LinearAlgebra.normalize!(L::LPDO; sqrt_localnorms! = [])
   N = length(L)
   resize!(sqrt_localnorms!, N)
   # TODO: replace with:
-  #blob = ket(L, 1) * δ(siteinds(L, 1)) * bra(L, 1)
+  #blob = noprime(ket(L, 1) * siteind(L, 1)) * bra(L, 1)
   blob = noprime(ket(L, 1), "Site") * bra(L, 1)
   localZ = norm(blob)
   blob /= sqrt(localZ)

--- a/test/choi.jl
+++ b/test/choi.jl
@@ -1,0 +1,45 @@
+using PastaQ
+using Random
+using Test
+
+@testset "tr Choi" begin
+  Random.seed!(1234)
+  N = 4
+  depth = 4
+  nshots = 100
+  gates = randomcircuit(N, depth)
+  data, Λ = getsamples(N, gates, nshots;
+                       process = true,
+                       noise = ("amplitude_damping", (γ = 0.01,)))
+  @test tr(Λ.M) ≈ 16
+  @test tr(Λ.M) ≈ tr(PastaQ.splitchoi(Λ).M)
+  @test tr(Λ) ≈ 16
+  @test tr(Λ) ≈ tr(PastaQ.splitchoi(Λ))
+end
+
+@testset "normalize! Choi" begin
+  Random.seed!(1234)
+  N = 4
+  depth = 4
+  nshots = 10_000
+  gates = randomcircuit(N, depth)
+  data, Φ = getsamples(N, gates, nshots;
+                       process = true,
+                       noise = ("amplitude_damping", (γ = 0.01,)))
+  N = length(Φ)
+  χ = 8
+  ξ = 2
+  # Initialize the Choi LPDO
+  Λ0 = randomprocess(Φ; mixed = true, χ = χ, ξ = ξ)
+  # Initialize stochastic gradient descent optimizer
+  opt = SGD(η = 0.1)
+  # Run process tomography
+  println("Run process tomography to learn noisy process Λ")
+  Λ = tomography(data, Λ0;
+                 optimizer = opt,
+                 batchsize = 500,
+                 epochs = 5,
+                 target = Φ)
+  @test fidelity_bound(Φ.M, Λ.M) < 1
+  @test fidelity_bound(Φ, Λ) < 1
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using Test
 
 @testset "PastaQ.jl" begin
   @testset "$filename" for filename in (
+    "choi.jl",
     "utils.jl",
     "gates.jl",
     "circuits.jl",


### PR DESCRIPTION
This fixes `normalize!(::MPO)` and `tr(::MPO)`. It relies on a new version of ITensors.jl that is not yet registered, but will be soon.

Fixes #141.