### PR TITLE
minor fixes + fixed norm bug in xvalidation

### DIFF
--- a/examples/4_finitetemperature.jl
+++ b/examples/4_finitetemperature.jl
@@ -110,7 +110,7 @@ depth = Δ ÷ τ # Depth of the circuit
 steps = β ÷ Δ # Total number of circuit application
 
 # Initialize the density operator
-ρ = circuit(H)
+ρ = identity_mpo(H)
 
 println("Running imaginary time evolution to approximate the density matrix ρ = exp(-βH):")
 for b in 1:steps

--- a/src/circuits/circuits.jl
+++ b/src/circuits/circuits.jl
@@ -20,12 +20,14 @@ function lineararray(N::Int)
     push!(cycle,(j,j+1))
   end
   push!(twoqubit_bonds,cycle)
-  # Cycle 2
-  cycle = []
-  for j in 2:2:N-1
-    push!(cycle,(j,j+1))
+  if N>2
+    # Cycle 2
+    cycle = []
+    for j in 2:2:N-1
+      push!(cycle,(j,j+1))
+    end
+    push!(twoqubit_bonds,cycle)
   end
-  push!(twoqubit_bonds,cycle)
   return twoqubit_bonds
 end
 
@@ -249,3 +251,17 @@ function qft(N::Int; inverse::Bool = false)
   return gates
 end
 
+"""
+    ghz(N::Int)
+
+Generate a list of gates for the GHZ state
+
+ψ = (|0,0,…,0⟩ + |1,1,…,1⟩)/√2
+"""
+function ghz(N::Int)
+  gates = [("H",1)]
+  for j in 1:N-1
+    push!(gates,("CX",(j,j+1)))
+  end
+  return gates
+end

--- a/src/circuits/gates.jl
+++ b/src/circuits/gates.jl
@@ -210,6 +210,15 @@ gate(::GateName"√SWAP") =
    0 (1-im)/2 (1+im)/2 0
    0        0        0 1]
 
+gate(::GateName"iSwap") = 
+  [1 0 0 0
+   0 0 im 0
+   0 im 0 0
+   0 0 0 1];
+
+gate(::GateName"iSw") = 
+  gate("iSwap")
+
 # Ising (XX) coupling gate
 gate(::GateName"XX"; ϕ::Number) =
   [    cos(ϕ)          0          0 -im*sin(ϕ)

--- a/src/circuits/runcircuit.jl
+++ b/src/circuits/runcircuit.jl
@@ -117,12 +117,12 @@ end
 
 Initialize a circuit MPO
 """
-circuit(sites::Vector{<:Index}) = MPO(sites, "Id")
+identity_mpo(sites::Vector{<:Index}) = MPO(sites, "Id")
 
-circuit(N::Int) = circuit(siteinds("Qubit", N))
+identity_mpo(N::Int) = identity_mpo(siteinds("Qubit", N))
 
-circuit(M::Union{MPS,MPO,LPDO}) =
-  circuit(hilbertspace(M))
+identity_mpo(M::Union{MPS,MPO,LPDO}) =
+  identity_mpo(hilbertspace(M))
 
 """----------------------------------------------
                   CIRCUIT FUNCTIONS 
@@ -344,23 +344,23 @@ function runcircuit(N::Int, gates::Vector{<:Tuple};
                       noise = noise,
                       cutoff = cutoff,
                       maxdim = maxdim,
-                      svd_alg = "divide_and_conquer")
+                      svd_alg = svd_alg)
   
   elseif process==true
     if isnothing(noise)
-      U = circuit(N) # = 1⊗1⊗1⊗…⊗1
+      U = identity_mpo(N) # = 1⊗1⊗1⊗…⊗1
       return runcircuit(U, gates;
                         noise = nothing,
                         apply_dag = false,
                         cutoff = cutoff,
                         maxdim = maxdim,
-                        svd_alg = "divide_and_conquer") 
+                        svd_alg = svd_alg) 
     else
       return choimatrix(N, gates;
                         noise = noise,
                         cutoff = cutoff,
                         maxdim = maxdim,
-                        svd_alg = "divide_and_conquer")
+                        svd_alg = svd_alg)
     end
   end
     
@@ -400,14 +400,14 @@ function choimatrix(N::Int, gates::Vector{<:Tuple};
     error("choi matrix requires noise")
   end
   # Initialize circuit MPO
-  U = circuit(N)
+  U = identity_mpo(N)
   addtags!(U,"Input",plev=0,tags="Qubit")
   addtags!(U,"Output",plev=1,tags="Qubit")
   prime!(U,tags="Input")
   prime!(U,tags="Link")
   
   s = [siteinds(U,tags="Output")[j][1] for j in 1:length(U)]
-  compiler = circuit(s)
+  compiler = identity_mpo(s)
   prime!(compiler,-1,tags="Qubit") 
   gate_tensors = buildcircuit(compiler, gates; noise = noise)
 

--- a/src/distances.jl
+++ b/src/distances.jl
@@ -92,6 +92,15 @@ function frobenius_distance(ρ::Union{MPO, LPDO},
   return sqrt(distance)
 end
 
+frobenius_distance(ψ::MPS, ρ::Union{MPO,LPDO}) =
+  frobenius_distance(MPO(ψ), ρ)
+
+frobenius_distance(ρ::Union{MPO,LPDO}, ψ::MPS) = 
+  frobenius_distance(ψ,ρ)
+
+frobenius_distance(ψ::MPS, ϕ::MPS) = 
+  frobenius_distance(MPO(ψ),MPO(ϕ))
+
 """
     fidelity_bound(ρ::Union{MPO, LPDO}, σ::Union{MPO, LPDO})
 
@@ -111,6 +120,15 @@ function fidelity_bound(ρ::Union{MPO, LPDO},
   normalize!(σ̃)
   return real(inner(ρ̃, σ̃))
 end
+
+fidelity_bound(ψ::MPS, ρ::Union{MPO,LPDO}) =
+  fidelity(ψ, ρ)
+
+fidelity_bound(ρ::Union{MPO,LPDO}, ψ::MPS) = 
+  fidelity(ρ,ψ)
+
+fidelity_bound(ψ::MPS, ϕ::MPS) = 
+  fidelity(ψ,ϕ)
 
 """
     fidelity(ρ::ITensor, σ::ITensor)

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -23,7 +23,7 @@ export
 # circuits/runcircuit.jl
   # Methods
   qubits,
-  circuit,
+  identity_mpo,
   resetqubits!,
   buildcircuit,
   applygate,

--- a/src/processtomography.jl
+++ b/src/processtomography.jl
@@ -401,6 +401,7 @@ function tomography(train_data::Matrix{Pair{String,Pair{String, Int}}},
   target = get(kwargs,:target,nothing)
   test_data = get(kwargs,:test_data,nothing)
   outputpath = get(kwargs,:fout,nothing)
+  outputlevel = get(kwargs,:outputlevel,1)
   trace_preserving_regularizer = get(kwargs,:trace_preserving_regularizer,0.0)
 
   optimizer = copy(optimizer)
@@ -461,12 +462,19 @@ function tomography(train_data::Matrix{Pair{String,Pair{String, Int}}},
     end # end @elapsed
 
     # Metrics
-    print("$ep : ")
-    @printf("⟨-logP⟩ = %.4f (train) ",train_loss)
+    if outputlevel == 1
+      print("$ep : ")
+      @printf("⟨-logP⟩ = %.4f (train) ",train_loss)
+    end
     # Cost function on held-out validation data
     if !isnothing(test_data)
-      test_loss = nll(model,test_data) 
-      @printf(", %.4f (test) ",test_loss)
+      normalized_model = copy(model)
+      sqrt_localnorms = []
+      normalize!(normalized_model; sqrt_localnorms! = sqrt_localnorms)
+      test_loss = nll(normalized_model,test_data) 
+      if outputlevel == 1
+        @printf(", %.4f (test) ",test_loss)
+      end
       if test_loss < best_test_loss
         best_test_loss = test_loss
         best_model = copy(model)
@@ -474,30 +482,40 @@ function tomography(train_data::Matrix{Pair{String,Pair{String, Int}}},
     else
       best_model = copy(model)
     end
-    @printf(" | ") 
     # TP measure
     trace_preserving_distance = TP(model)
-    @printf("|TrᵢΛ-I| = %.2E  ", trace_preserving_distance)
+    if outputlevel == 1
+      @printf(" | ") 
+      @printf("|TrᵢΛ-I| = %.2E  ", trace_preserving_distance)
+    end
     # Fidelities
     if !isnothing(target)
       if ((model.X isa MPO) & (target isa MPO))
         frob_dist = frobenius_distance(model,target)
         Fbound = fidelity_bound(model,target)
-        @printf("|ρ-σ| = %.3E  ",frob_dist)
-        @printf("Tr[ρσ] = %.3E  ",Fbound)
+        if outputlevel == 1
+          @printf("|ρ-σ| = %.3E  ",frob_dist)
+          @printf("Tr[ρσ] = %.3E  ",Fbound)
+        end
         if (length(model) <= 8)
           disable_warn_order!()
           F = fidelity(prod(model), prod(target))
           reset_warn_order!()
-          @printf("F(ρ,σ) = %.3E  ",F)
+          if outputlevel == 1
+            @printf("F(ρ,σ) = %.3E  ",F)
+          end
         end
       else
         F = fidelity(model,target)
-        @printf("F(ρ,σ) = %.3E  ",F)
+        if outputlevel == 1
+          @printf("F(ρ,σ) = %.3E  ",F)
+        end
       end
     end
-    @printf("(%.3fs)",ep_time)
-    print("\n")
+    if outputlevel == 1
+      @printf("(%.3fs)",ep_time)
+      print("\n")
+    end
 
     # Measure
     if !isnothing(observer!)
@@ -516,7 +534,9 @@ function tomography(train_data::Matrix{Pair{String,Pair{String, Int}}},
   
     tot_time += ep_time
   end
-  @printf("Total Time = %.3f sec\n",tot_time)
+  if outputlevel == 1
+    @printf("Total Time = %.3f sec\n",tot_time)
+  end
   return best_model
 end
 

--- a/src/statetomography.jl
+++ b/src/statetomography.jl
@@ -471,7 +471,8 @@ function tomography(train_data::Matrix{Pair{String, Int}}, L::LPDO;
   target = get(kwargs,:target,nothing)
   test_data = get(kwargs,:test_data,nothing)
   outputpath = get(kwargs,:fout,nothing)
-
+  outputlevel = get(kwargs,:outputlevel,1)
+  
   optimizer = copy(optimizer)
   model = copy(L)
 
@@ -520,12 +521,19 @@ function tomography(train_data::Matrix{Pair{String, Int}}, L::LPDO;
     end # end @elapsed
     
     # Metrics
-    print("$ep : ")
-    @printf("⟨-logP⟩ = %.4f (train) ",train_loss)
+    if outputlevel == 1
+      print("$ep : ")
+      @printf("⟨-logP⟩ = %.4f (train) ",train_loss)
+    end
     # Cost function on held-out validation data
     if !isnothing(test_data)
-      test_loss = nll(model,test_data) 
-      @printf(", %.4f (test) ",test_loss)
+      normalized_model = copy(model)
+      sqrt_localnorms = []
+      normalize!(normalized_model; sqrt_localnorms! = sqrt_localnorms)
+      test_loss = nll(normalized_model, test_data) 
+      if outputlevel  == 1
+        @printf(", %.4f (test) ",test_loss)
+      end
       if test_loss < best_test_loss
         best_test_loss = test_loss
         best_model = copy(model)
@@ -533,27 +541,37 @@ function tomography(train_data::Matrix{Pair{String, Int}}, L::LPDO;
     else
       best_model = copy(model)
     end
-    @printf(" | ")
+    if outputlevel == 1
+      @printf(" | ")
+    end
     # Fidelities
     if !isnothing(target)
       if ((model.X isa MPO) & (target isa MPO))
         frob_dist = frobenius_distance(model,target)
         Fbound = fidelity_bound(model,target)
-        @printf("|ρ-σ| = %.3E  ",frob_dist)
-        @printf("Tr[ρσ] = %.3E  ",Fbound)
+        if outputlevel == 1
+          @printf("|ρ-σ| = %.3E  ",frob_dist)
+          @printf("Tr[ρσ] = %.3E  ",Fbound)
+        end
         if (length(model) <= 8)
           disable_warn_order!()
           F = fidelity(prod(model), prod(target))
           reset_warn_order!()
-          @printf("F(ρ,σ) = %.3E  ",F)
+          if outputlevel == 1
+            @printf("F(ρ,σ) = %.3E  ",F)
+          end
         end
       else
         F = fidelity(model,target)
-        @printf("F(ρ,σ) = %.3E  ",F)
+        if outputlevel == 1
+          @printf("F(ρ,σ) = %.3E  ",F)
+        end
       end
     end
-    @printf("(%.3fs)",ep_time)
-    print("\n")
+    if outputlevel == 1
+      @printf("(%.3fs)",ep_time)
+      print("\n")
+    end
     # Measure
     if !isnothing(observer!)
       measure!(observer!;
@@ -570,7 +588,9 @@ function tomography(train_data::Matrix{Pair{String, Int}}, L::LPDO;
 
     tot_time += ep_time
   end
-  @printf("Total Time = %.3f sec\n",tot_time)
+  if outputlevel == 1
+    @printf("Total Time = %.3f sec\n",tot_time)
+  end
   return best_model
 end
 

--- a/test/distances.jl
+++ b/test/distances.jl
@@ -73,7 +73,10 @@ end
 
   F = frobenius_distance(ρ_mpo,σ_mpo)
   @test T ≈ F
-    
+  @test F ≈ frobenius_distance(ψ1,σ_mpo)
+  @test F ≈ frobenius_distance(ρ_mpo,ψ2)
+  @test F ≈ frobenius_distance(ψ1,ψ2)
+  
   Random.seed!(1111)
   ρ = randomstate(ψ1;mixed=true,χ=2,ξ=2)
   
@@ -91,7 +94,7 @@ end
 
   F = frobenius_distance(ρ, σ_mpo)
   @test T ≈ F
-
+  @test F ≈ frobenius_distance(ρ_mpo,ψ2)
 
   Random.seed!(1111)
   σ = randomstate(ψ1;mixed=true,χ=2,ξ=2)
@@ -110,6 +113,7 @@ end
 
   F = frobenius_distance(ρ_mpo,σ)
   @test T ≈ F
+  @test F ≈ frobenius_distance(ψ1,σ_mpo)
   
   Random.seed!(1111)
   ρ = randomstate(N;mixed=true,χ=2,ξ=2)
@@ -151,7 +155,10 @@ end
   f = tr(conj(transpose(ρ_mat/Kρ)) * (σ_mat/Kσ))
   F̃ = fidelity_bound(ρ_mpo,σ_mpo)
   @test f ≈ F̃
-    
+  @test F̃ ≈ fidelity(ψ1,σ_mpo)
+  @test F̃ ≈ fidelity(ρ_mpo,ψ2)
+  @test F̃ ≈ fidelity(ψ1,ψ2)
+   
   Random.seed!(1111)
   ρ = randomstate(ψ1;mixed=true,χ=2,ξ=2)
   
@@ -166,7 +173,7 @@ end
   f = tr(conj(transpose(ρ_mat/Kρ)) * (σ_mat/Kσ))
   F̃ = fidelity_bound(ρ,σ_mpo)
   @test f ≈ F̃
-
+  @test F̃ ≈ fidelity(ρ_mpo,ψ2)
 
   Random.seed!(1111)
   σ = randomstate(ψ1;mixed=true,χ=2,ξ=2)
@@ -181,7 +188,8 @@ end
   f = tr(conj(transpose(ρ_mat/Kρ)) * (σ_mat/Kσ))
   F̃ = fidelity_bound(ρ_mpo,σ)
   @test f ≈ F̃
-  
+  @test F̃ ≈ fidelity(ψ1,σ_mpo)
+
   Random.seed!(1111)
   ρ = randomstate(N;mixed=true,χ=2,ξ=2)
   Random.seed!(1111)
@@ -198,7 +206,6 @@ end
   f = tr(conj(transpose(ρ_mat/Kρ)) * (σ_mat/Kσ))
   F̃ = fidelity_bound(ρ,σ)
   @test f ≈ F̃
-  
 end
 
 

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -41,7 +41,9 @@ opt = SGD(η = 0.01)
 ψ = tomography(data, ψ0;
                optimizer = opt,
                epochs = 2,
+               outputlevel=0,
                target = Ψ)
+
 
 data, ϱ = readsamples("../examples/data/qst_circuit_noisy_test.h5")
 N = length(ϱ)     # Number of qubits
@@ -53,6 +55,7 @@ opt = SGD(η = 0.01)
 ρ = tomography(data, ρ0;
                optimizer = opt,
                epochs = 2,
+               outputlevel=0,
                target = ϱ)
 
 Random.seed!(1234)
@@ -65,6 +68,7 @@ V = tomography(data, V0;
                optimizer = opt,
                epochs = 2,
                trace_preserving_regularizer = 0.1,
+               outputlevel=0,
                target = U)
 
 # Noisy circuit
@@ -79,4 +83,5 @@ opt = SGD(η = 0.1)
                optimizer = opt,
                epochs = 2,
                trace_preserving_regularizer = 0.1,
+               outputlevel=0,
                target = ϱ)

--- a/test/runcircuit.jl
+++ b/test/runcircuit.jl
@@ -3,101 +3,6 @@ using ITensors
 using Test
 using LinearAlgebra
 
-function runcircuitFULL(N::Int,tensors::Array)
-  """ Assumes NN gates, and for 2q gates-> [q+1,q] """
-  ngates = length(tensors)
-  id_mat = [1. 0.;0. 1.]
-  swap   = [1 0 0 0;
-            0 0 1 0;
-            0 1 0 0;
-            0 0 0 1]
-  U = 1.0
-  for j in 1:N
-    U = kron(U,id_mat)
-  end
-  for tensor in tensors
-    # 1q gate
-    if (length(inds(tensor)) == 2)
-      site = getsitenumber(firstind(tensor,"Site"))
-      u = 1.0
-      for j in 1:N
-        if (j == site)
-          u = kron(u,array(tensor))
-        else
-          u = kron(u,id_mat)
-        end
-      end
-      U = u * U
-    #2q gate
-    else
-      site1 = getsitenumber(inds(tensor,plev=1)[2])
-      site2 = getsitenumber(inds(tensor,plev=1)[1])
-      site = min(site1,site2)
-      if (site1<site2)
-        gate = reshape(array(tensor),(4,4))
-      else
-        gate = swap * reshape(array(tensor),(4,4)) * swap
-      end
-      # NN 2q gate
-      if abs(site1-site2) == 1
-        u = 1.0
-        for j in 1:N-1
-          if (j == site)
-            u = kron(u,gate)
-          else
-            u = kron(u,id_mat)
-          end
-        end
-        U = u * U
-      else
-        nswaps = abs(site1-site2)-1
-        if site1 > site2
-          start = site2
-        else
-          start = site1
-        end
-        # Swap
-        for n in 1:nswaps
-          u = 1.0
-          for j in 1:N-1
-            if j == start+n-1
-              u = kron(u,swap)
-            else
-              u = kron(u,id_mat)
-            end
-          end
-          U = u * U
-        end
-        # Gate
-        u = 1.0
-        for j in 1:N-1
-          if j == start+nswaps
-            u = kron(u,gate)
-            #u = kron(u,reshape(array(tensor),(4,4)))
-          else
-            u = kron(u,id_mat)
-          end
-        end
-        U = u * U
-        # Unswap
-        for n in 1:nswaps
-          u = 1.0
-          for j in 1:N-1
-            if j == start+nswaps-n
-              u = kron(u,swap)
-            else
-              u = kron(u,id_mat)
-            end
-          end
-          U = u * U
-        end
-      end
-    end
-  end
-  psi = U[:,1]
-  return psi,U
-end
-
 function state_to_int(state::Array)
   index = 0
   for j in 1:length(state)
@@ -136,7 +41,7 @@ end
 
 @testset "circuit MPO initialization" begin
   N = 5
-  U = circuit(N)
+  U = identity_mpo(N)
   @test length(U) == N
   U_mat = PastaQ.fullmatrix(U)
   exact_mat = Matrix{ComplexF64}(I, 1<<N, 1<<N)


### PR DESCRIPTION
Changes implemented in this PR:

- fix the normalization when computing the cost function on the cross-validation data set (in both state and process tomography).
- Add a keyword arg for printing infos about training in tomography.
- add iSwap gate
- add pre-defined circuit to generate the GHZ state
- fix bug in layer sequence for `randomcircuit` with `N=2`
- add `frobenius_distance` for pure states, as well as `fidelity_bound` (though here if one (or both ) of the two state is pure just returns the fidelity.
- change the syntax `circuit(...)` to `identity_mpo(...)`. 