### PR TITLE
productstate/productoperator functions to replace trivialstate/trivialprocess

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,7 @@ jobs:
       matrix:
         version:
           - '1.4'
+          - '1.5'
         os:
           - ubuntu-latest
           #- macOS-latest

--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,6 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 HDF5 = "0.13.1, 0.14"
-ITensors = "0.1.34"
+ITensors = "0.1.39"
 StatsBase = "0.33"
 julia = "1.4"

--- a/src/PastaQ.jl
+++ b/src/PastaQ.jl
@@ -15,6 +15,7 @@ include("itensor.jl")
 include("lpdo.jl")
 
 include("circuits/gates.jl")
+include("circuits/productstates.jl")
 include("circuits/qubitarrays.jl")
 include("circuits/circuits.jl")
 include("circuits/runcircuit.jl")

--- a/src/circuits/getsamples.jl
+++ b/src/circuits/getsamples.jl
@@ -305,10 +305,10 @@ function getsamples(hilbert0::Vector{<:Index},
   # Generate preparation/measurement gates
   meas_gates = measurementgates(basis)
   # Prepare quantum state
-  M_in = trivialstate(hilbert0, prep)
+  M_in = productstate(hilbert0, prep)
 
   # TODO: delete
-  #M0 = trivialstate(hilbert0)
+  #M0 = productstate(hilbert0)
   #prep_gates = preparationgates(prep)
   #M_in  = runcircuit(M0, prep_gates)
 
@@ -459,7 +459,7 @@ function getsamples(gates::Array,preps::Array, bases::Array ;
   N = size(preps)[2]
   nshots = size(preps)[1]
   
-  ψ0 = trivialstate(N)
+  ψ0 = productstate(N)
   hilbert = hilbertspace(ψ0) 
   # Pre-compile quantum channel
   gate_tensors = buildcircuit(ψ0, gates; noise=noise, kwargs...)

--- a/src/circuits/productstates.jl
+++ b/src/circuits/productstates.jl
@@ -66,5 +66,6 @@ productoperator(N::Int) = productoperator(siteinds("Qubit", N))
 productoperator(M::Union{MPS, MPO, LPDO}) = 
   productoperator(hilbertspace(M))
 
-productoperator(sites::Vector{<:Index}) = MPO(sites, "Id")
+productoperator(sites::Vector{<:Index}) =
+  MPO([op("Id", s) for s in sites])
 

--- a/src/circuits/productstates.jl
+++ b/src/circuits/productstates.jl
@@ -1,0 +1,70 @@
+"""
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+-                                QUANTUM STATES                                -
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+"""
+
+"""
+    productstate(N::Int)
+    
+    productstate(sites::Vector{<:Index})
+
+
+Initialize qubits to an MPS wavefunction in the 0 state (`|ψ⟩ = |0⟩ ⊗ |0⟩ ⊗ …`).
+"""
+productstate(N::Int) = productstate(siteinds("Qubit", N))
+
+productstate(sites::Vector{<:Index}) = productMPS(sites, "0")
+
+"""
+    productstate(M::Union{MPS,MPO,LPDO})
+
+Initialize qubits on the Hilbert space of a reference state,
+given as `MPS`, `MPO` or `LPDO`.
+"""
+productstate(M::Union{MPS,MPO,LPDO}) = productstate(hilbertspace(M))
+
+"""
+    productstate(N::Int, states::Vector{T})
+
+    productstate(sites::Vector{<:Index}, states::Vector{T})
+
+    productstate(M::Union{MPS,MPO,LPDO}, states::Vector{T})
+
+Initialize the qubits to a given product state, where the state `T` can be specified either
+with a Vector of states specified as Strings or bit values (0 and 1).
+"""
+productstate(N::Int, states::Vector) =
+  productstate(siteinds("Qubit", N), states)
+
+productstate(M::Union{MPS,MPO,LPDO}, states::Vector) =
+  productstate(hilbertspace(M), states; mixed = mixed)
+
+productstate(sites::Vector{<:Index}, states::Vector) =
+  MPS(state.(states, sites))
+
+productstate(sites::Vector{<:Index}, states::Vector{<:Integer}) =
+  MPS(state.(string.(Int.(states)), sites))
+
+productstate(sites::Vector{<:Index}, state::Union{String, Integer}) =
+  productstate(sites, fill(state, length(sites)))
+
+productstate(sites::Vector{<:Index}, states::Function) =
+  productstate(sites, map(states, 1:length(sites)))
+
+"""
+    productoperator(N::Int)
+
+    productoperator(sites::Vector{<:Index})
+
+Initialize an MPO that is a product of identity operators.
+"""
+productoperator(N::Int) = productoperator(siteinds("Qubit", N))
+
+productoperator(M::Union{MPS, MPO, LPDO}) = 
+  productoperator(hilbertspace(M))
+
+productoperator(sites::Vector{<:Index}) = MPO(sites, "Id")
+

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -12,7 +12,7 @@ qubits(N::Int; mixed::Bool = false) =
   qubits(siteinds("Qubit", N); mixed = mixed)
 
 function qubits(sites::Vector{<:Index}; mixed::Bool = false)
-  @warn "Method `qubits` is deprecated, use `trivialstate` or `trivialprocess` instead."
+  @warn "Method `qubits` is deprecated, use `productstate` or `productoperator` instead."
   ψ = productMPS(sites, "0")
   mixed && return MPO(ψ)
   return ψ
@@ -40,7 +40,7 @@ qubits(N::Int, states::Vector{String}; mixed::Bool = false) =
 
 function qubits(sites::Vector{<:Index}, states::Vector{String};
                 mixed::Bool = false)
-  @warn "Method `qubits` is deprecated, use `trivialstate` or `trivialprocess` instead."
+  @warn "Method `qubits` is deprecated, use `productstate` or `productoperator` instead."
   N = length(sites)
   @assert N == length(states)
 

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -24,8 +24,8 @@ export
 
 # circuits/runcircuit.jl
   # Methods
-  trivialstate,
-  trivialprocess,
+  productstate,
+  productoperator,
   qubits,
   buildcircuit,
   runcircuit,

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -1,8 +1,14 @@
 import Base:
+  copy,
+  getindex,
   sqrt,
-  push!
+  length,
+  push!,
+  setindex!
 
 import ITensors:
+  # types
+  MPO,
   # circuits/gates.jl
   space,
   state,

--- a/src/inputoutput.jl
+++ b/src/inputoutput.jl
@@ -10,18 +10,18 @@ function readsamples(input_path::String)
   fin = h5open(input_path, "r")
   # Check if the data is for state tomography or process tomography
   # Process tomography
-  if exists(fin, "inputs")
+  if haskey(fin, "inputs")
     inputs = read(fin, "inputs")
     bases = read(fin, "bases")
     outcomes = read(fin,"outcomes")
     data = inputs .=> (bases .=> outcomes)
   # Measurements in bases
-  elseif exists(fin, "bases") 
+  elseif haskey(fin, "bases") 
     bases = read(fin, "bases")
     outcomes = read(fin,"outcomes")
     data = bases .=> outcomes
   # Measurements in Z basis
-  elseif exists(fin, "outcomes")
+  elseif haskey(fin, "outcomes")
     data = read(fin, "outcomes")
   else
     close(fin)
@@ -29,11 +29,11 @@ function readsamples(input_path::String)
   end
 
   # Check if a model is saved, if so read it and return it
-  if exists(fin, "model")
+  if haskey(fin, "model")
     g = fin["model"]
 
-    if exists(attrs(g), "type")
-      typestring = read(attrs(g)["type"])
+    if haskey(attributes(g), "type")
+      typestring = read(attributes(g)["type"])
       modeltype = eval(Meta.parse(typestring))
       model = read(fin, "model", modeltype)
     else

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -1,3 +1,8 @@
+#
+# Functions defined for ITensors.jl objects
+# that may be moved to ITensors.jl
+#
+
 
 #
 # imports.jl
@@ -7,12 +12,28 @@ import Base:
   isapprox,
   eltype
 
-#
-# Functions defined for ITensors.jl objects
-# that may be moved to ITensors.jl
+using ITensors: AbstractMPS
+
+######################################################
+# TagSet
 #
 
-using ITensors: AbstractMPS
+function random_tags()
+  ts = TagSet()
+  ntags = length(ts.data)
+  tagtype = eltype(ts.data)
+  for n in 1:length(ts.data)
+    ts = addtags(ts, ITensors.Tag(rand(tagtype)))
+  end
+  return ts
+end
+
+######################################################
+# IndexSet
+#
+
+has_indpairs(is::IndexSet, plevs::Pair{Int, Int}) =
+  any(i -> hasplev(i, first(plevs)) && setprime(i, last(plevs)) in is, is)
 
 ######################################################
 # ITensor
@@ -28,6 +49,14 @@ end
 ######################################################
 # MPS
 #
+
+## # For |ψ⟩ and |ϕ⟩, return |ψ⟩⊗⟨ϕ|
+## function ITensors.outer(ψ::MPS, ϕ::MPS; kwargs...)
+##   # XXX: implement by converting to MPOs and
+##   # contracting the MPOs?
+##   @assert ψ == ϕ'
+##   return MPO(ϕ; kwargs...)
+## end
 
 eltype(ψ::MPS) = ITensor
 eltype(ψ::MPO) = ITensor

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -1,7 +1,21 @@
 
 #
+# imports.jl
+#
+
+import Base:
+  isapprox,
+  eltype
+
+#
 # Functions defined for ITensors.jl objects
 # that may be moved to ITensors.jl
+#
+
+using ITensors: AbstractMPS
+
+######################################################
+# ITensor
 #
 
 function sqrt(ρ::ITensor)
@@ -10,4 +24,36 @@ function sqrt(ρ::ITensor)
   sqrtD .= sqrt.(D)
   return U' * sqrtD * dag(U)
 end
+
+######################################################
+# MPS
+#
+
+eltype(ψ::MPS) = ITensor
+eltype(ψ::MPO) = ITensor
+
+function promote_leaf_eltypes(ψ::AbstractMPS)::Type{<:Number}
+  eltypeψ = eltype(ψ[1])
+  for n in 2:length(ψ)
+    eltypeψ = promote_type(eltypeψ, eltype(ψ[n]))
+  end 
+  return eltypeψ
+end
+
+function isapprox(x::AbstractMPS, y::AbstractMPS;
+                  atol::Real = 0,
+                  rtol::Real = Base.rtoldefault(promote_leaf_eltypes(x), promote_leaf_eltypes(y), atol))
+  #d = norm(x - y)
+  normx² = inner(x, x)
+  normy² = inner(y, y)
+  d² = normx² + normy² - 2 * real(inner(x, y))
+  @assert imag(d²) < 1e-15
+  d = sqrt(abs(d²))
+  normx = sqrt(abs(normx²))
+  normy = sqrt(abs(normy²))
+  return d <= max(atol, rtol * max(normx, normy))
+end
+
+isapprox(x::AbstractMPS, y::ITensor; kwargs...) = isapprox(prod(x), y; kwargs...)
+isapprox(x::ITensor, y::AbstractMPS; kwargs...) = isapprox(y, x; kwargs...)
 

--- a/src/lpdo.jl
+++ b/src/lpdo.jl
@@ -87,7 +87,7 @@ An MPO `M` is normalized by `tr(M)`, and the resulting MPO will have the propert
 
 An LPDO `L = X X†` is normalized by `tr(L) = tr(X X†)`, so each `X` is normalized by `√tr(L) = √tr(X X†)`. The resulting LPDO will have the property `tr(L) ≈ 1`.
 
-Passing a vector `v` as the keyword arguments `localnorms!` (`sqrt_localnorms!`) will fill the vector with the (square root) of the normalization factor per site. For an MPS `ψ`, `prod(v) ≈ norm(ψ)`. For an MPO `M`, `prod(v) ≈ tr(M). For an LPDO `L`, `prod(v)^2 ≈ tr(L)`.
+Passing a vector `v` as the keyword arguments `localnorms!` (`sqrt_localnorms!`) will fill the vector with the (square root) of the normalization factor per site. For an MPS `ψ`, `prod(v) ≈ norm(ψ)`. For an MPO `M`, `prod(v) ≈ tr(M)`. For an LPDO `L`, `prod(v)^2 ≈ tr(L)`.
 """
 function normalize!(M::MPO;
                     plev = 0 => 1,
@@ -188,7 +188,7 @@ function ITensors.MPO(lpdo0::LPDO)
   return rho
 end
 
-function HDF5.write(parent::Union{HDF5File,HDF5Group},
+function HDF5.write(parent::Union{HDF5.File,HDF5.Group},
                     name::AbstractString,
                     L::LPDO)
   g = g_create(parent, name)
@@ -196,7 +196,7 @@ function HDF5.write(parent::Union{HDF5File,HDF5Group},
   write(parent, "X", L.X)
 end
 
-function HDF5.read(parent::Union{HDF5File, HDF5Group},
+function HDF5.read(parent::Union{HDF5.File, HDF5.Group},
                    name::AbstractString,
                    ::Type{LPDO{XT}}) where {XT}
   g = g_open(parent, name)

--- a/src/observer.jl
+++ b/src/observer.jl
@@ -132,8 +132,9 @@ function measure!(observer::Observer, M::Union{MPS,MPO,LPDO}, reference_indices:
   end
 end
 
-measure!(observer::Observer, M::Union{MPS,MPO,LPDO}) =  
+function measure!(observer::Observer, M::Union{MPS,MPO,LPDO})
   measure!(observer, M, hilbertspace(M))
+end
 
 
 Base.copy(observer::Observer) = Observer(copy(observer.measurements)) 

--- a/src/tomography/processtomography.jl
+++ b/src/tomography/processtomography.jl
@@ -43,7 +43,7 @@ for the Choi matrix.
 function nll(L::LPDO{MPO},data::Matrix{Pair{String,Pair{String, Int}}})
   # if the MPO in LPDO{MPO} is a unitary MPO (instead of a MPO with Kraus index)
   # then transform the MPO to MPS and run the nll on that
-  #if !hastags(L.X[1],"Purifier")
+  #if !hastags(L.X[1], default_purifier_tags)
   #  return nll(_UnitaryMPOtoMPS(copy(L.X)), data)
   #end
   
@@ -237,7 +237,7 @@ function gradnll(L::LPDO{MPO},
 
   kraus = Index[]
   for j in 1:N
-    push!(kraus,firstind(ρ[j], "Purifier"))
+    push!(kraus,firstind(ρ[j], default_purifier_tags))
   end
 
   nthreads = Threads.nthreads()
@@ -482,28 +482,28 @@ function grad_TrΦ²(Λ::LPDO{MPO}; sqrt_localnorms = nothing)
   R = Vector{ITensor}(undef, N)
   L[1] = bra(Λ,1) * noprime(ket(Λ,1),tags="Output")
   L[1] = L[1] * prime(bra(Λ,1)',"Link")
-  L[1] = L[1] * prime(prime(noprime(ket(Λ,1),"Input"),2,"Link"),"Purifier")
+  L[1] = L[1] * prime(prime(noprime(ket(Λ,1),"Input"),2,"Link"), default_purifier_tags)
   for j in 2:N-1
     L[j] = L[j-1] * bra(Λ,j)
     L[j] = L[j] * noprime(ket(Λ,j),tags="Output") 
     L[j] = L[j] * prime(bra(Λ,j)',"Link")
-    L[j] = L[j] * prime(prime(noprime(ket(Λ,j),"Input"),2,"Link"),"Purifier") 
+    L[j] = L[j] * prime(prime(noprime(ket(Λ,j),"Input"),2,"Link"), default_purifier_tags) 
   end
   trΦ² = L[N-1] * bra(Λ,N)
   trΦ² = trΦ² * noprime(ket(Λ,N),tags="Output")
   trΦ² = trΦ² * prime(bra(Λ,N)',"Link") 
-  trΦ² = trΦ² * prime(prime(noprime(ket(Λ, N),"Input"),2,"Link"),"Purifier") 
+  trΦ² = trΦ² * prime(prime(noprime(ket(Λ, N),"Input"),2,"Link"), default_purifier_tags) 
   trΦ² = real(trΦ²[]) 
   
   R[N] = bra(Λ,N) * noprime(ket(Λ,N),tags="Output")
   R[N] = R[N] * prime(bra(Λ,N)',"Link") 
-  R[N] = R[N] * prime(prime(noprime(ket(Λ, N),"Input"),2,"Link"),"Purifier") 
+  R[N] = R[N] * prime(prime(noprime(ket(Λ, N),"Input"),2,"Link"), default_purifier_tags) 
   
   for j in reverse(2:N-1)
     R[j] = R[j+1] * bra(Λ,j)
     R[j] = R[j] * noprime(ket(Λ,j),tags="Output") 
     R[j] = R[j] * prime(bra(Λ,j)',"Link")
-    R[j] = R[j] * prime(prime(noprime(ket(Λ,j),"Input"),2,"Link"),"Purifier") 
+    R[j] = R[j] * prime(prime(noprime(ket(Λ,j),"Input"),2,"Link"), default_purifier_tags) 
   end
   
   gradients = Vector{ITensor}(undef, N)
@@ -649,7 +649,7 @@ function tomography(train_data::Matrix{Pair{String,Pair{String, Int}}}, L::LPDO;
       end
       
       if model isa LPDO{MPS}
-        update!(observer!, LPDO(choi_mps_to_unitary_mpo(normalized_model)), best_model, tot_time, train_loss, test_loss)
+        update!(observer!, choi_mps_to_unitary_mpo(normalized_model), best_model, tot_time, train_loss, test_loss)
       else
         update!(observer!,normalized_model, best_model,tot_time, train_loss, test_loss)
       end

--- a/src/tomography/tomographyutils.jl
+++ b/src/tomography/tomographyutils.jl
@@ -75,7 +75,7 @@ end
 
 """
     update!(observer::Observer,
-            normalized_model::LPDO,
+            normalized_model::Union{MPS,MPO,LPDO},
             best_model::LPDO,
             simulation_time::Float64,
             train_loss::Float64,
@@ -85,7 +85,7 @@ Update the observer for quantum tomography.
 Perform measuremenst and record data.
 """
 function update!(observer::Observer,
-                 normalized_model::LPDO,
+                 normalized_model::Union{MPS,MPO,LPDO},
                  best_model::LPDO,
                  simulation_time::Float64,
                  train_loss::Float64,
@@ -96,13 +96,12 @@ function update!(observer::Observer,
   if !isnothing(test_loss)
     push!(observer.measurements["test_loss"][2], test_loss)
   end
-  
-  # check whether there is an object with Kraus index if so, feed it
-  # directly to the measurement. Otherwise, take the inner object
-  # as argument, which may be a MPS wavefunction, a unitary MPO, or
-  # a MPO density matrix.
-  M = (normalized_model.purifier_tag == ts"" ? normalized_model.X : normalized_model)
-  measure!(observer, M)
+  if normalized_model isa LPDO{MPS}
+    measure!(observer, normalized_model.X)
+  else
+    measure!(observer, normalized_model)
+  end
+  return observer
 end
 
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -266,7 +266,7 @@ mpotags(M::Union{MPS,MPO}) = mpotags(LPDO(M)).X
 
 
 """
-    unitaryMPO_to_choiMPS(U::MPO)
+    unitary_mpo_to_choi_mps(U::MPO)
 
 
      MPO          MPS (vectorized MPO) 
@@ -278,9 +278,23 @@ mpotags(M::Union{MPS,MPO}) = mpotags(LPDO(M)).X
                   
 Transforms a unitary MPO into a Choi MPS with appropriate tags.
 """
-#_unitaryMPO_to_choiMPS(L::LPDO{MPO}) = LPDO(convert(MPS, _choitags(L).X)) 
 unitary_mpo_to_choi_mps(U::MPO) = convert(MPS, choitags(U))
 unitary_mpo_to_choi_mps(L::LPDO{MPO}) = unitary_mpo_to_choi_mps(L.X)
+
+"""
+    unitary_mpo_to_choi_mpo(U::MPO)
+
+
+     MPO                   MPO
+  σ₁ -o- σ₁′     (σ₁ⁱ,σ₁ᴼ) =o= (σ₁′ⁱ,σ₁′ᴼ)   
+      |                     | 
+  σ₂ -o- σ₂′  ⟶  (σ₂ⁱ,σ₂ᴼ) =o= (σ₂′ⁱ,σ₂′ᴼ)
+      |                     | 
+  σ₃ -o- σ₃′     (σ₃ⁱ,σ₃ᴼ) =o= (σ₃′ⁱ,σ₃′ᴼ)
+                  
+Convert a unitary MPO to a Choi matrix represented as an MPO with 4 site indices.
+"""
+unitary_mpo_to_choi_mpo(U::MPO) = MPO(LPDO(convert(MPS, choitags(U))))
 
 """
     _choiMPS_to_unitaryMPO(Ψ::MPS)

--- a/test/circuitops.jl
+++ b/test/circuitops.jl
@@ -4,7 +4,7 @@ using Test
 using LinearAlgebra
 
 @testset "apply gate: Id" begin
-  psi = trivialstate(2)
+  psi = productstate(2)
   gate_data = ("I", 1)
   psi = runcircuit(psi,gate_data)
   @test PastaQ.array(psi) ≈ [1.,0.,0.,0.]
@@ -12,7 +12,7 @@ end
   
 @testset "apply gate: X" begin
   # Build gate first, then apply using an ITensor
-  psi = trivialstate(2)
+  psi = productstate(2)
   site = 1
   gate_data = ("X", 1)
   psi=runcircuit(psi,gate_data)
@@ -21,7 +21,7 @@ end
 end
 
 @testset "apply gate: Y" begin
-  psi = trivialstate(2)
+  psi = productstate(2)
   site = 1
   gate_data = ("Y", 1)
   psi=runcircuit(psi,gate_data)
@@ -31,7 +31,7 @@ end
 
 @testset "apply gate: Z" begin
   # Build gate first, then apply using an ITensor
-  psi = trivialstate(2)
+  psi = productstate(2)
   site = 1
   gate_data = ("Z", 1)
   psi=runcircuit(psi,gate_data)
@@ -41,7 +41,7 @@ end
 
 @testset "apply gate: H" begin
   # Build gate first, then apply using an ITensor
-  psi = trivialstate(2)
+  psi = productstate(2)
   site = 1
   gate_data = ("H", 1)
   psi=runcircuit(psi,gate_data)
@@ -49,11 +49,11 @@ end
 end
 
 @testset "apply gate: S" begin
-  psi = trivialstate(1)
+  psi = productstate(1)
   gate_data = ("S", 1)
   psi=runcircuit(psi,gate_data)
   @test PastaQ.array(psi[1]) ≈ [1.,0.]
-  psi = trivialstate(1)
+  psi = productstate(1)
   gate_data = ("X", 1)
   psi=runcircuit(psi,gate_data)
   gate_data = ("S", 1)
@@ -62,11 +62,11 @@ end
 end
 
 @testset "apply gate: T" begin
-  psi = trivialstate(1)
+  psi = productstate(1)
   gate_data = ("T", 1)
   psi=runcircuit(psi,gate_data)
   @test PastaQ.array(psi[1]) ≈ [1.,0.]
-  psi = trivialstate(1)
+  psi = productstate(1)
   gate_data = ("X", 1)
   psi=runcircuit(psi,gate_data)
   gate_data = ("T", 1)
@@ -76,11 +76,11 @@ end
 
 @testset "apply gate: Rx" begin
   θ = π * rand()
-  psi = trivialstate(1)
+  psi = productstate(1)
   gate_data = ("Rx",1,(θ=θ,))
   psi=runcircuit(psi,gate_data)
   @test PastaQ.array(psi[1]) ≈ [cos(θ/2.),-im*sin(θ/2.)]
-  psi = trivialstate(1)
+  psi = productstate(1)
   psi=runcircuit(psi,("X",1))
   #PastaQ.applygate!(psi,"X",1)
   gate_data = ("Rx",1,(θ=θ,))
@@ -90,11 +90,11 @@ end
 
 @testset "apply gate: Ry" begin
   θ = π * rand()
-  psi = trivialstate(1)
+  psi = productstate(1)
   gate_data = ("Ry",1,(θ=θ,))
   psi=runcircuit(psi,gate_data)
   @test PastaQ.array(psi[1]) ≈ [cos(θ/2.),sin(θ/2.)]
-  psi = trivialstate(1)
+  psi = productstate(1)
   psi=runcircuit(psi,("X",1))
   gate_data = ("Ry",1,(θ=θ,))
   psi=runcircuit(psi,gate_data)
@@ -104,11 +104,11 @@ end
 
 @testset "apply gate: Rz" begin
   ϕ = 2π * rand()
-  psi = trivialstate(1)
+  psi = productstate(1)
   gate_data = ("Rz",1,(ϕ=ϕ,))
   psi=runcircuit(psi,gate_data)
   @test PastaQ.array(psi[1]) ≈ [1.0, 0.0]
-  psi = trivialstate(1)
+  psi = productstate(1)
   psi=runcircuit(psi,("X",1))
   gate_data = ("Rz",1,(ϕ=ϕ,))
   psi=runcircuit(psi,gate_data)
@@ -119,11 +119,11 @@ end
   θ = 1.0
   ϕ = 2.0
   λ = 3.0
-  psi = trivialstate(1)
+  psi = productstate(1)
   gate_data = ("Rn",1,(θ=θ,ϕ=ϕ,λ=λ))
   psi=runcircuit(psi,gate_data)
   @test PastaQ.array(psi[1]) ≈ [cos(θ/2.),exp(im*ϕ) * sin(θ/2.)]
-  psi = trivialstate(1)
+  psi = productstate(1)
   psi=runcircuit(psi,("X",1))
   gate_data = ("Rn",1,(θ=θ,ϕ=ϕ,λ=λ))
   psi=runcircuit(psi,gate_data)
@@ -133,57 +133,57 @@ end
 
 
 @testset "apply gate: prep X+/X-" begin
-  psi = trivialstate(1, ["X+"])
+  psi = productstate(1, ["X+"])
   @test PastaQ.array(psi) ≈ 1/sqrt(2.)*[1.,1.]
   
-  psi = trivialstate(1, ["X-"])
+  psi = productstate(1, ["X-"])
   @test PastaQ.array(psi) ≈ 1/sqrt(2.)*[1.,-1.]
 end
 
 @testset "apply gate: prep Y+/Y-" begin
-  psi = trivialstate(1, ["Y+"])
+  psi = productstate(1, ["Y+"])
   @test PastaQ.array(psi) ≈ 1/sqrt(2.)*[1.,im]
   
-  psi = trivialstate(1, ["Y-"])
+  psi = productstate(1, ["Y-"])
   @test PastaQ.array(psi) ≈ 1/sqrt(2.)*[1.,-im]
 end
 
 @testset "apply gate: prep Z+/Z-" begin
-  psi = trivialstate(1, ["Z+"])
+  psi = productstate(1, ["Z+"])
   @test PastaQ.array(psi) ≈ [1.,0.]
   
-  psi = trivialstate(1, ["Z-"])
+  psi = productstate(1, ["Z-"])
   @test PastaQ.array(psi) ≈ [0.,1.]
 end
 
 @testset "apply gate: meas X" begin
-  psi = trivialstate(1, ["X+"])
+  psi = productstate(1, ["X+"])
   gate_data = ("basisX", 1, (dag = true,))
   psi=runcircuit(psi,gate_data)
   @test PastaQ.array(psi) ≈ [1.,0.]
-  psi = trivialstate(1, ["X-"])
+  psi = productstate(1, ["X-"])
   gate_data = ("basisX", 1, (dag = true,))
   psi=runcircuit(psi,gate_data)
   @test PastaQ.array(psi) ≈ [0.,1.]
 end
 
 @testset "apply gate: meas Y" begin
-  psi = trivialstate(1, ["Y+"])
+  psi = productstate(1, ["Y+"])
   gate_data = ("basisY", 1, (dag = true,))
   psi=runcircuit(psi,gate_data)
   @test PastaQ.array(psi) ≈ [1.,0.]
-  psi = trivialstate(1, ["Y-"])
+  psi = productstate(1, ["Y-"])
   gate_data = ("basisY", 1, (dag = true,))
   psi=runcircuit(psi,gate_data)
   @test PastaQ.array(psi) ≈ [0.,1.]
 end
 
 @testset "apply gate: meas Z" begin
-  psi = trivialstate(1)
+  psi = productstate(1)
   gate_data = ("basisZ", 1, (dag = true,))
   psi=runcircuit(psi,gate_data)
   @test PastaQ.array(psi) ≈ [1.,0.]
-  psi = trivialstate(1, ["Z-"])
+  psi = productstate(1, ["Z-"])
   gate_data = ("basisZ", 1, (dag = true,))
   psi=runcircuit(psi,gate_data)
   @test PastaQ.array(psi) ≈ [0.,1.]
@@ -193,14 +193,14 @@ end
 
 @testset "apply gate: CX" begin
   # CONTROL - TARGET
-  psi = trivialstate(2)
+  psi = productstate(2)
   # |00> -> |00> = (1 0 0 0) (natural order)
   gate_data = ("CX",(1,2))
   psi=runcircuit(psi,gate_data)
   psi_vec = PastaQ.array(psi)
   @test psi_vec ≈ [1.,0.,0.,0.]
   
-  psi = trivialstate(2)
+  psi = productstate(2)
   # |10> -> |11> = (0 0 0 1) (natural order)
   gate_data = ("X",1)
   psi=runcircuit(psi,gate_data)
@@ -209,7 +209,7 @@ end
   psi_vec = PastaQ.array(psi)
   @test psi_vec ≈ [0.,0.,0.,1.]
   
-  psi = trivialstate(2)
+  psi = productstate(2)
   # |01> -> |01> = (0 1 0 0) (natural order)
   gate_data = ("X",2)
   psi=runcircuit(psi,gate_data)
@@ -218,7 +218,7 @@ end
   psi_vec = PastaQ.array(psi)
   @test psi_vec ≈ [0.,1.,0.,0.]
   
-  psi = trivialstate(2)
+  psi = productstate(2)
   # |11> -> |10> = (0 0 1 0) (natural order)
   gate_data = ("X",1)
   psi=runcircuit(psi,gate_data)
@@ -233,14 +233,14 @@ end
 
 @testset "apply gate: CY" begin
   # CONTROL - TARGET
-  psi = trivialstate(2)
+  psi = productstate(2)
   # |00> -> |00> = (1 0 0 0) (natural order)
   gate_data = ("CY",(1,2))
   psi=runcircuit(psi,gate_data)
   psi_vec = PastaQ.array(psi)
   @test psi_vec ≈ [1.,0.,0.,0.]
   
-  psi = trivialstate(2)
+  psi = productstate(2)
   # |10> -> i|11> = (0 0 0 i) (natural order)
   gate_data = ("X",1)
   psi=runcircuit(psi,gate_data)
@@ -249,7 +249,7 @@ end
   psi_vec = PastaQ.array(psi)
   @test psi_vec ≈ [0.,0.,0.,im]
   
-  psi = trivialstate(2)
+  psi = productstate(2)
   # |01> -> |01> = (0 1 0 0) (natural order)
   gate_data = ("X",2)
   psi=runcircuit(psi,gate_data)
@@ -258,7 +258,7 @@ end
   psi_vec = PastaQ.array(psi)
   @test psi_vec ≈ [0.,1.,0.,0.]
   
-  psi = trivialstate(2)
+  psi = productstate(2)
   # |11> -> -i|10> = (0 0 -i 0) (natural order)
   gate_data = ("X",1)
   psi=runcircuit(psi,gate_data)
@@ -270,14 +270,14 @@ end
   @test psi_vec ≈ [0.,0.,-im,0.]
   
   # TARGET - CONTROL
-  psi = trivialstate(2)
+  psi = productstate(2)
   # |00> -> |00> = (1 0 0 0) (natural order)
   gate_data = ("CY",(2,1))
   psi=runcircuit(psi,gate_data)
   psi_vec = PastaQ.array(psi)
   @test psi_vec ≈ [1.,0.,0.,0.]
   
-  psi = trivialstate(2)
+  psi = productstate(2)
   # |10> -> |10> = (0 0 1 0) (natural order)
   gate_data = ("X",1)
   psi=runcircuit(psi,gate_data)
@@ -286,7 +286,7 @@ end
   psi_vec = PastaQ.array(psi)
   @test psi_vec ≈ [0.,0.,1.,0.]
   
-  psi = trivialstate(2)
+  psi = productstate(2)
   # |01> -> i|11> = (0 0 0 i) (natural order)
   gate_data = ("X",2)
   psi=runcircuit(psi,gate_data)
@@ -295,7 +295,7 @@ end
   psi_vec = PastaQ.array(psi)
   @test psi_vec ≈ [0.,0.,0.,im]
   
-  psi = trivialstate(2)
+  psi = productstate(2)
   # |11> -> -i|01> = (0 -i 0 0) (natural order)
   gate_data = ("X",1)
   psi=runcircuit(psi,gate_data)
@@ -310,14 +310,14 @@ end
 
 @testset "apply gate: CZ" begin
   # CONTROL - TARGET
-  psi = trivialstate(2)
+  psi = productstate(2)
   # |00> -> |00> = (1 0 0 0) (natural order)
   gate_data = ("CZ",(1,2))
   psi=runcircuit(psi,gate_data)
   psi_vec = PastaQ.array(psi)
   @test psi_vec ≈ [1.,0.,0.,0.]
   
-  psi = trivialstate(2)
+  psi = productstate(2)
   # |10> -> |10> = (0 0 1 0) (natural order)
   gate_data = ("X",1)
   psi=runcircuit(psi,gate_data)
@@ -326,7 +326,7 @@ end
   psi_vec = PastaQ.array(psi)
   @test psi_vec ≈ [0.,0.,1.,0.]
   
-  psi = trivialstate(2)
+  psi = productstate(2)
   # |01> -> |01> = (0 1 0 0) (natural order)
   gate_data = ("X",2)
   psi=runcircuit(psi,gate_data)
@@ -335,7 +335,7 @@ end
   psi_vec = PastaQ.array(psi)
   @test psi_vec ≈ [0.,1.,0.,0.]
   
-  psi = trivialstate(2)
+  psi = productstate(2)
   # |11> -> -|11> = (0 0 0 -1) (natural order)
   gate_data = ("X",1)
   psi=runcircuit(psi,gate_data)
@@ -348,14 +348,14 @@ end
   
 
   # CONTROL - TARGET
-  psi = trivialstate(2)
+  psi = productstate(2)
   # |00> -> |00> = (1 0 0 0) (natural order)
   gate_data = ("CZ",(2,1))
   psi=runcircuit(psi,gate_data)
   psi_vec = PastaQ.array(psi)
   @test psi_vec ≈ [1.,0.,0.,0.]
   
-  psi = trivialstate(2)
+  psi = productstate(2)
   # |10> -> |10> = (0 0 1 0) (natural order)
   gate_data = ("X",1)
   psi=runcircuit(psi,gate_data)
@@ -364,7 +364,7 @@ end
   psi_vec = PastaQ.array(psi)
   @test psi_vec ≈ [0.,0.,1.,0.]
   
-  psi = trivialstate(2)
+  psi = productstate(2)
   # |01> -> |01> = (0 1 0 0) (natural order)
   gate_data = ("X",2)
   psi=runcircuit(psi,gate_data)
@@ -373,7 +373,7 @@ end
   psi_vec = PastaQ.array(psi)
   @test psi_vec ≈ [0.,1.,0.,0.]
   
-  psi = trivialstate(2)
+  psi = productstate(2)
   # |11> -> -|11> = (0 0 0 -1) (natural order)
   gate_data = ("X",1)
   psi=runcircuit(psi,gate_data)
@@ -388,14 +388,14 @@ end
 
 @testset "apply gate: Sw" begin
   # CONTROL - TARGET
-  psi = trivialstate(2)
+  psi = productstate(2)
   # |00> -> |00> = (1 0 0 0) (natural order)
   gate_data = ("Sw",(1,2))
   psi=runcircuit(psi,gate_data)
   psi_vec = PastaQ.array(psi)
   @test psi_vec ≈ [1.,0.,0.,0.]
   
-  psi = trivialstate(2)
+  psi = productstate(2)
   # |10> -> |01> = (0 1 0 0) (natural order)
   gate_data = ("X",1)
   psi=runcircuit(psi,gate_data)
@@ -404,7 +404,7 @@ end
   psi_vec = PastaQ.array(psi)
   @test psi_vec ≈ [0.,1.,0.,0.]
   
-  psi = trivialstate(2)
+  psi = productstate(2)
   # |01> -> |10> = (0 0 1 0) (natural order)
   gate_data = ("X",2)
   psi=runcircuit(psi,gate_data)
@@ -413,7 +413,7 @@ end
   psi_vec = PastaQ.array(psi)
   @test psi_vec ≈ [0.,0.,1.,0.]
   
-  psi = trivialstate(2)
+  psi = productstate(2)
   # |11> -> |11> = (0 0 0 1) (natural order)
   gate_data = ("X",1)
   psi=runcircuit(psi,gate_data)

--- a/test/distances.jl
+++ b/test/distances.jl
@@ -11,10 +11,10 @@ using Random
   circuit2 = randomcircuit(N,3)
   # MPS wavefunction
   ψ1 = runcircuit(circuit1)
-  ψ2 = runcircuit(trivialstate(ψ1),circuit2)
+  ψ2 = runcircuit(productstate(ψ1),circuit2)
   # MPO density matrix
-  ρ1 = runcircuit(trivialstate(ψ1), circuit1; noise = ("DEP",(p=0.01,)))
-  ρ2 = runcircuit(trivialstate(ψ1), circuit2; noise = ("DEP",(p=0.01,)))
+  ρ1 = runcircuit(productstate(ψ1), circuit1; noise = ("DEP",(p=0.01,)))
+  ρ2 = runcircuit(productstate(ψ1), circuit2; noise = ("DEP",(p=0.01,)))
   # LPDO density matrix
   ϱ1 = normalize!(randomstate(ψ1; mixed = true))
   ϱ2 = normalize!(randomstate(ψ1; mixed = true))

--- a/test/getsamples.jl
+++ b/test/getsamples.jl
@@ -67,7 +67,7 @@ end
 @testset "measurements" begin
   N = 4
   depth = 10
-  ψ0 = trivialstate(N)
+  ψ0 = productstate(N)
   gates = randomcircuit(N,depth)
   ψ = runcircuit(ψ0,gates)
   ψ_vec = PastaQ.array(ψ)
@@ -95,7 +95,7 @@ end
 @testset "measurement projections" begin
   N = 8
   nshots = 20
-  ψ0 = trivialstate(N)
+  ψ0 = productstate(N)
   bases = randombases(N,nshots)
   
   depth = 8
@@ -214,7 +214,7 @@ end
   
   for n in 1:ntrial
     mgates = PastaQ.measurementgates(bases[n,:])
-    ψ_in  = trivialstate(N, preps[n,:])
+    ψ_in  = productstate(N, preps[n,:])
     ψ_out = runcircuit(ψ_in,gates)
     
     Ψ_out = PastaQ.projectunitary(U,preps[n,:])
@@ -240,7 +240,7 @@ end
   preps = PastaQ.randompreparations(N,ntrial)
   for n in 1:ntrial
     mgates = PastaQ.measurementgates(bases[n,:])
-    ψ_in  = trivialstate(N, preps[n,:])
+    ψ_in  = productstate(N, preps[n,:])
     ρ_out = runcircuit(ψ_in, gates; noise = ("amplitude_damping", (γ = 0.1,)))
     
     Λ_out = PastaQ.projectchoi(Λ,preps[n,:])

--- a/test/observer.jl
+++ b/test/observer.jl
@@ -189,7 +189,7 @@ end
   @test length(results(obs,"norm")) == depth 
   @test results(obs,"norm")[end] ≈ norm(ψ)
   @test results(obs,"maxlinkdim")[end] ≈ maxlinkdim(ψ)
-  ϕ = trivialstate(ψ) 
+  ϕ = productstate(ψ) 
   f1(ψ::MPS) = fidelity(ψ,ϕ)
   f2(ψ::MPS) = fidelity_bound(ψ,ϕ) 
   obs = Observer(f1)
@@ -206,7 +206,7 @@ end
   Random.seed!(1234)
   data,Ψ = readsamples("../examples/data/qst_circuit_test.h5")
   test_data = copy(data[1:10,:])
-  N = length(Ψ)     # Number of trivialstate
+  N = length(Ψ)     # Number of productstate
   χ = maxlinkdim(Ψ) # Bond dimension of variational MPS
   ψ0 = randomstate(Ψ; χ = χ, σ = 0.1)
   opt = SGD(η = 0.01)
@@ -253,7 +253,7 @@ end
   Random.seed!(1234)
   data,V = readsamples("../examples/data/qpt_circuit_test.h5")
   test_data = copy(data[1:10,:])
-  N = length(V)     # Number of trivialstate
+  N = length(V)     # Number of productstate
   χ = maxlinkdim(V) # Bond dimension of variational MPS
   U0 = randomprocess(V; χ = χ, σ = 0.1)
   opt = SGD(η = 0.01)

--- a/test/productstates.jl
+++ b/test/productstates.jl
@@ -1,0 +1,52 @@
+using ITensors
+using PastaQ
+using Test
+
+@testset "productstate" begin
+  s = siteinds("Qubit", 4)
+
+  states0 = [state("0", s[n]) for n in 1:length(s)]
+  states1 = [state("1", s[n]) for n in 1:length(s)]
+  statesXp = [state("X+", s[n]) for n in 1:length(s)]
+  statesYm = [state("Y-", s[n]) for n in 1:length(s)]
+
+  ψ0 = productstate(s)
+  @test ψ0 isa MPS
+  @test eltype(ψ0) == ITensor
+  @test PastaQ.promote_leaf_eltypes(ψ0) == Float64
+  @test ψ0 ≈ prod(states0)
+
+  @test productstate(s, 0) ≈ ψ0
+  @test productstate(s, "0") ≈ ψ0
+
+  ψXp = productstate(s, "X+")
+  @test ψXp isa MPS
+  @test PastaQ.promote_leaf_eltypes(ψXp) == Float64
+  @test ψXp ≈ prod(statesXp)
+
+  ψYm = productstate(s, "Y-")
+  @test ψYm isa MPS
+  @test PastaQ.promote_leaf_eltypes(ψYm) == ComplexF64
+  @test prod(ψYm) ≈ prod(statesYm)
+
+  @test productstate(s, fill("0", length(s))) ≈ ψ0
+  @test productstate(s, fill(0, length(s))) ≈ ψ0
+  @test productstate(s, fill("X+", length(s))) ≈ prod(statesXp)
+  @test productstate(s, fill("Y-", length(s))) ≈ prod(statesYm)
+
+  @test productstate(s, n -> isodd(n) ? 1 : 0) ≈ states1[1] * states0[2] * states1[3] * states0[4]
+  @test productstate(s, n -> isodd(n) ? "1" : "0") ≈ states1[1] * states0[2] * states1[3] * states0[4]
+  @test productstate(s, n -> isodd(n) ? "Y-" : "X+") ≈ statesYm[1] * statesXp[2] * statesYm[3] * statesXp[4]
+end
+
+@testset "productoperator" begin
+  s = siteinds("Qubit", 4)
+
+  gatesI = [gate("Id", s, n) for n in 1:length(s)]
+
+  I = productoperator(s)
+  @test PastaQ.promote_leaf_eltypes(I) == Float64
+  @test prod(I) ≈ prod(gatesI)
+  @test I ≈ prod(gatesI)
+end
+

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -6,11 +6,11 @@ using Random
 
 @testset "array" begin
   N = 5
-  ψ = trivialstate(N)
+  ψ = productstate(N)
   ψvec = array(ψ)
   @test size(ψvec) == (1<<N,)
   
-  ρ = trivialstate(N; mixed = true)
+  ρ = MPO(productstate(N))
   ρmat = array(ρ)
   @test size(ρmat) == (1<<N,1<<N)
   
@@ -28,8 +28,8 @@ end
 
 @testset "hilbertspace" begin
   N = 5
-  ψ = trivialstate(N)
-  ρ = trivialstate(ψ; mixed = true)
+  ψ = productstate(N)
+  ρ = MPO(productstate(ψ))
   Λ = randomstate(ψ; mixed = true)
 
   @test PastaQ.hilbertspace(ψ) == siteinds(ψ)


### PR DESCRIPTION
This replaces the functions `trivialstate`/`trivialprocess` with `productstate`/`productoperator`, and additionally removes the `mixed = true` case in the favor of converting to an MPO with `MPO(productstate(s))`.

Right now, `trivialstate` makes a state without link indices, for no particular reason other than that I was interested to see if it worked and because it makes the code a bit simpler. This exposed some bugs in ITensors/NDTensors, so I'm working through those right now.

Left to do:
- [x] Fix some test errors in fidelity (probably related to updating the `MPO(::MPS)` function).
- [x] Remove `choifidelity` in favor of `fidelity`.