### PR TITLE
Fix bug when multiplying gates and applying function

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PastaQ"
 uuid = "30b07047-aa8b-4c78-a4e8-24d720215c19"
 authors = ["Giacomo Torlai <gttorlai@amazon.com>", "Matthew Fishman <mfishman@flatironinstitute.org>"]
-version = "0.0.14"
+version = "0.0.15"
 
 [deps]
 Convex = "f65535da-76fb-5f13-bab9-19810c17039a"

--- a/src/circuits/gates.jl
+++ b/src/circuits/gates.jl
@@ -409,13 +409,13 @@ gate(s::String, args...; kwargs...) = gate(GateName(s), args...; kwargs...)
 # Version that accepts a dimension for the gate,
 gate(gn::GateName, dims::Tuple; kwargs...) = gate(gn; kwargs...)
 
-function gate(gn::GateName, s1::Index, ss::Index...; 
-              dag::Bool = false,
-              f = nothing,
-              kwargs...)
-  s = tuple(s1, ss...)
-  rs = reverse(s)
-  
+
+"""
+    combinegates(gn::GateName, s::Tuple; kwargs...)
+
+Generate a gate (matrix) given a set of operations in the gatename string
+"""
+function combinegates(gn::GateName, s::Tuple; kwargs...)
   name = string(ITensors.name(gn))
   name = filter(x -> !isspace(x), name)
   
@@ -425,36 +425,38 @@ function gate(gn::GateName, s1::Index, ss::Index...;
     !isempty(kwargs) && error("Composition of parametric gates not allowed")
     gate1 = name[1:prevind(name, pluspos.start)]
     gate2 = name[nextind(name, pluspos.start):end]
-    return gate(GateName(gate1), s...; dag=dag,f=f,kwargs...) + gate(GateName(gate2), s...; dag=dag,f=f,kwargs...)
+    return combinegates(GateName(gate1), dim.(s); kwargs...) + combinegates(GateName(gate2), dim.(s); kwargs...)
   end
-  
   # next check for multiplication
   starpos = findfirst("*", name)
   if !isnothing(starpos)
     !isempty(kwargs) && error("Composition of parametric gates not allowed")
     gate1 = name[1:prevind(name, starpos.start)]
     gate2 = name[nextind(name, starpos.start):end]
-    # note the inverted order, which is related to how we apply the gates
-    return product(gate(GateName(gate1), s...; dag=dag,f=f,kwargs...), 
-                   gate(GateName(gate2), s...; dag=dag,f=f,kwargs...))
+    return combinegates(GateName(gate1), dim.(s); kwargs...) * combinegates(GateName(gate2), dim.(s); kwargs...)
   end
+  return gate(gn, dim.(s); kwargs...)
+end
 
-  # if `f` is being passed
-  if !isnothing(f)
-    # if `f` isa a function, apply `f` to the gate
-    if f isa Function
-      g = f(gate(gn, dim.(s); kwargs...))
-    # if not, pass it as a regular argument
-    else
-      g = gate(gn, dim.(s); f = f, kwargs...)
-    end
-  else
-    g = gate(gn, dim.(s); kwargs...)
-  end
+function gate(gn::GateName, s1::Index, ss::Index...; 
+              dag::Bool = false,
+              f = nothing,
+              kwargs...)
+  s = tuple(s1, ss...)
+  rs = reverse(s)
+  # temporary block on f. To be revised in gate system refactoring.
+  !isnothing(f) && !(f isa Function) && error("gate parameter `f` not allowed")
+
+  # generate dense gate
+  g = combinegates(gn, s; kwargs...)
   
   # conjugate the gate if `dag=true`
   g = dag ? Array(g') : g
+  
+  # apply a function if passed
+  g = !isnothing(f) ? f(g) : g
     
+  # generate itensor gate
   if ndims(g) == 1
     # TODO:
     #error("gate must have more than one dimension, use state(...) for state vectors.")

--- a/test/gates.jl
+++ b/test/gates.jl
@@ -718,6 +718,17 @@ end
   G = gate("Z")*gate("S") + gate("T") * gate("X") * gate("Y")
   gtest = gate("Z*S + T * X * Y", s[1])
   @test PastaQ.array(gtest) ≈ G
+
+
+  exp_cx = exp(0.1*cx)
+  gtest = gate("CX",s[1],s[2]; f = x -> exp(0.1*x))
+  @test PastaQ.array(gtest) ≈ exp_cx
+  
+  d = 3
+  q = siteinds("Qudit", 4; dim = d)
+  g1 = gate("a†a", q[1]; f = x -> exp(0.1*x))
+  g2 = gate("a† * a", q[1]; f = x -> exp(0.1*x))
+  @test g1 ≈ g2
 end
 
 


### PR DESCRIPTION
This PR provides a bug fix for the gate combination system. The bug originated from the fact that when a function `f` was passed, it was applied to each "sub-gate" operation, rather than to the final output of the combination. For example, if one passes `g = ("a† * a", 1, (f = myfunction))`, the output was actually `f(a†) * f(a)`, instead of `f(a†a)`.