### PR TITLE
Introduce `PastaQ.normalize!` to distinguish from `ITensors.normalize!`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PastaQ"
 uuid = "30b07047-aa8b-4c78-a4e8-24d720215c19"
 authors = ["Giacomo Torlai <gttorlai@amazon.com>", "Matthew Fishman <mfishman@flatironinstitute.org>"]
-version = "0.0.16"
+version = "0.0.17"
 
 [deps]
 Convex = "f65535da-76fb-5f13-bab9-19810c17039a"
@@ -22,7 +22,7 @@ Convex = "0.14.16"
 HDF5 = "0.13.1, 0.14, 0.15"
 ITensors = "0.1.41, 0.2"
 JLD2 = "0.4.14"
-Observers = "0.0.3"
+Observers = "0.0.6"
 Optimisers = "0.1.0"
 SCS = "0.7.1"
 StatsBase = "0.33"

--- a/examples/7_qst_circuit.jl
+++ b/examples/7_qst_circuit.jl
@@ -2,7 +2,7 @@ using PastaQ
 using Random
 using ITensors
 using Observers
-import Optimisers
+using Optimisers: Optimisers
 
 Random.seed!(1234)
 

--- a/examples/8_qpt_circuit.jl
+++ b/examples/8_qpt_circuit.jl
@@ -2,7 +2,7 @@ using PastaQ
 using Random
 using ITensors
 using Observers
-import Optimisers
+using Optimisers: Optimisers
 
 Random.seed!(1234)
 

--- a/src/PastaQ.jl
+++ b/src/PastaQ.jl
@@ -1,5 +1,5 @@
 module PastaQ
-  
+
 using ITensors
 using Random
 using LinearAlgebra

--- a/src/array.jl
+++ b/src/array.jl
@@ -45,7 +45,6 @@ function array(M::MPO; reverse::Bool=true)
   Mmat = prod(M) * dag(C) * C'
   c = combinedind(C)
   return ITensors.array(permute(Mmat, c', c))
- 
 end
 
 function array(L::LPDO{MPO}; reverse::Bool=true)
@@ -65,26 +64,25 @@ function array(L::LPDO{MPO}; reverse::Bool=true)
   return ITensors.array(permute(Mmat, c', c))
 end
 
+is_operator(T::ITensor) = !isempty(inds(T; plev=1))
 
-is_operator(T::ITensor) = 
-  !isempty(inds(T, plev = 1))
-  
 """
     PastaQ.array(T::ITensor; kwargs...)
 
 Transform a prod(MPS/MPO) into a dense vector/matrix
 """
-PastaQ.array(T::ITensor; kwargs...) = 
-  (is_operator(T) ? tomatrix(T; kwargs...) : tovector(T; kwargs...))
+function PastaQ.array(T::ITensor; kwargs...)
+  return (is_operator(T) ? tomatrix(T; kwargs...) : tovector(T; kwargs...))
+end
 
-function tovector(M::ITensor; reverse::Bool = true)
-  if length(inds(M,tags="n=1")) > 1
+function tovector(M::ITensor; reverse::Bool=true)
+  if length(inds(M; tags="n=1")) > 1
     error("Cannot transform a density matrix into a vector")
   end
   length(inds(M)) == 1 && return ITensors.array(M)
   s = []
-  for j in 1:length(inds(M,plev=0))
-    push!(s,firstind(M,tags="n=$(j)",plev=0))
+  for j in 1:length(inds(M; plev=0))
+    push!(s, firstind(M; tags="n=$(j)", plev=0))
   end
   if reverse
     s = Base.reverse(s)
@@ -93,20 +91,20 @@ function tovector(M::ITensor; reverse::Bool = true)
   return ITensors.array(M * C)
 end
 
-function tomatrix(M::ITensor; reverse::Bool = true)
-  if length(inds(M,tags="n=1")) == 1
+function tomatrix(M::ITensor; reverse::Bool=true)
+  if length(inds(M; tags="n=1")) == 1
     error("Cannot transform a wavefunctionm into a matrix")
   end
   length(inds(M)) == 2 && return ITensors.array(M)
   s = []
   if (hastags(M, "Input")) && (hastags(M, "Output"))
-    for j in 1:length(inds(M,plev=0))÷2
-      push!(s, firstind(M,tags="Input,n=$(j)",plev=0))
-      push!(s, firstind(M,tags="Output,n=$(j)",plev=0))
+    for j in 1:(length(inds(M; plev=0)) ÷ 2)
+      push!(s, firstind(M; tags="Input,n=$(j)", plev=0))
+      push!(s, firstind(M; tags="Output,n=$(j)", plev=0))
     end
   else
-    for j in 1:length(inds(M,plev=0))
-      push!(s,firstind(M,tags="n=$(j)",plev=0))
+    for j in 1:length(inds(M; plev=0))
+      push!(s, firstind(M; tags="n=$(j)", plev=0))
     end
   end
   if reverse
@@ -118,12 +116,12 @@ function tomatrix(M::ITensor; reverse::Bool = true)
   return ITensors.array(permute(Mmat, c', c))
 end
 
-function itensor(M::AbstractMatrix, sites::Vector{<:Index}; reverse::Bool = true)
+function itensor(M::AbstractMatrix, sites::Vector{<:Index}; reverse::Bool=true)
   sites = reverse ? Base.reverse(sites) : sites
   return ITensors.itensor(M, sites', ITensors.dag(sites))
 end
 
-function itensor(v::AbstractVector, sites::Vector{<:Index}; reverse::Bool = true) 
+function itensor(v::AbstractVector, sites::Vector{<:Index}; reverse::Bool=true)
   sites = reverse ? Base.reverse(sites) : sites
   return ITensors.itensor(v, sites)
 end

--- a/src/circuits/circuits.jl
+++ b/src/circuits/circuits.jl
@@ -124,8 +124,14 @@ function randomlayer(
 )
   layer = []
   for n in support
-    pars = randomparams(gatename, length(n); rng = rng) # the 2^n is for the Haar dimension
-    gatepars = (isempty(pars) ? (isempty(kwargs) ? nothing : values(kwargs)) : merge(pars,values(kwargs)))
+    pars = randomparams(gatename, length(n); rng=rng) # the 2^n is for the Haar dimension
+    gatepars = (
+      if isempty(pars)
+        (isempty(kwargs) ? nothing : values(kwargs))
+      else
+        merge(pars, values(kwargs))
+      end
+    )
     g = (isnothing(gatepars) ? (gatename, n) : (gatename, n, gatepars))
     push!(layer, g)
   end
@@ -148,16 +154,22 @@ are provided, each gate is sampled accordingly.
 
 function randomlayer(
   gatenames::Vector{<:AbstractString},
-  support::Union{Vector{<:Int}, AbstractRange, Vector{<:Tuple}};
+  support::Union{Vector{<:Int},AbstractRange,Vector{<:Tuple}};
   rng=Random.GLOBAL_RNG,
   weights::Union{Nothing,Vector{Float64}}=ones(length(gatenames)) / length(gatenames),
   kwargs...,
 )
   gate_id = StatsBase.sample(gatenames, StatsBase.Weights(weights), length(support))
   layer = []
-  for (i,n) in enumerate(support)
-    pars = randomparams(gate_id[i], length(n); rng = rng)
-    gatepars = (isempty(pars) ? (isempty(kwargs) ? nothing : values(kwargs)) : merge(pars,values(kwargs)))
+  for (i, n) in enumerate(support)
+    pars = randomparams(gate_id[i], length(n); rng=rng)
+    gatepars = (
+      if isempty(pars)
+        (isempty(kwargs) ? nothing : values(kwargs))
+      else
+        merge(pars, values(kwargs))
+      end
+    )
     g = (isnothing(gatepars) ? (gate_id[i], n) : (gate_id[i], n, gatepars))
     push!(layer, g)
   end
@@ -180,7 +192,7 @@ Build a random quantum circuit with `N` qubits and depth `depth`.
 """
 function randomcircuit(
   coupling_sequence::Vector;
-  depth::Int = 1,
+  depth::Int=1,
   twoqubitgates::Union{String,Vector{String}}="RandomUnitary",
   onequbitgates::Union{Nothing,String,Vector{String}}=nothing,
   layered::Bool=true,
@@ -188,12 +200,13 @@ function randomcircuit(
 )
   #N = (coupling_sequence isa Vector{AbstractVector} ? maximum(vcat([maximum.(c) for c in coupling_sequence]...)) : 
   #                                            maximum([maximum(c) for c in coupling_sequence]))
-  
+
   N = 0
-  coupling_sequence = coupling_sequence isa Vector{<:Tuple} ? [coupling_sequence] : coupling_sequence
+  coupling_sequence =
+    coupling_sequence isa Vector{<:Tuple} ? [coupling_sequence] : coupling_sequence
   for seq in coupling_sequence
     for b in seq
-      N = max(N,b[1],b[2])
+      N = max(N, b[1], b[2])
     end
   end
   circuit = Vector[]
@@ -232,13 +245,16 @@ function randomcircuit(size::Tuple; rotated::Bool=false, kwargs...)
 end
 
 function randomcircuit(L::Int, depth::Int; rotated::Bool=false, kwargs...)
-  error("randomcircuit(N::Int, depth::Int; kwargs...) is depracated\n
-         - for a 1d random circuit: randomcircuit(N::Int; depth = depth, kwargs...)\n
-         - for a 2d random circuit: randomcircuit((Lx, Ly); depth = depth, kwargs...)")
+  return error(
+    "randomcircuit(N::Int, depth::Int; kwargs...) is depracated\n
+     - for a 1d random circuit: randomcircuit(N::Int; depth = depth, kwargs...)\n
+     - for a 2d random circuit: randomcircuit((Lx, Ly); depth = depth, kwargs...)"
+  )
 end
 
-ITensors.dag(single_gate::Tuple{String,Union{Int,Tuple}}) = 
-  (single_gate[1], single_gate[2], (dag = true,))
+function ITensors.dag(single_gate::Tuple{String,Union{Int,Tuple}})
+  return (single_gate[1], single_gate[2], (dag=true,))
+end
 
 function ITensors.dag(single_gate::Tuple{String,Union{Int,Tuple},NamedTuple})
   prev_dag = get(single_gate[3], :dag, false)
@@ -246,9 +262,6 @@ function ITensors.dag(single_gate::Tuple{String,Union{Int,Tuple},NamedTuple})
   return (single_gate[1], single_gate[2], nt)
 end
 
-ITensors.dag(layer::Vector{<:Any}) = 
-  [ITensors.dag(g) for g in reverse(layer)]
+ITensors.dag(layer::Vector{<:Any}) = [ITensors.dag(g) for g in reverse(layer)]
 
-ITensors.dag(circuit::Vector{<:Vector{<:Any}}) = 
-  [dag(layer) for layer in reverse(circuit)]
-
+ITensors.dag(circuit::Vector{<:Vector{<:Any}}) = [dag(layer) for layer in reverse(circuit)]

--- a/src/circuits/gates.jl
+++ b/src/circuits/gates.jl
@@ -93,8 +93,7 @@ gate(::GateName"Rx"; θ::Number) = [
   -im*sin(θ / 2) cos(θ / 2)
 ]
 
-gate(::GateName"RX"; kwargs...) = 
-  gate("Rx"; kwargs...)
+gate(::GateName"RX"; kwargs...) = gate("Rx"; kwargs...)
 
 # Rotation around Y-axis
 gate(::GateName"Ry"; θ::Number) = [
@@ -102,8 +101,7 @@ gate(::GateName"Ry"; θ::Number) = [
   sin(θ / 2) cos(θ / 2)
 ]
 
-gate(::GateName"RY"; kwargs...) = 
-  gate("Ry"; kwargs...)
+gate(::GateName"RY"; kwargs...) = gate("Ry"; kwargs...)
 
 # Rotation around Z-axis
 gate(::GateName"Rz"; ϕ::Number) = [
@@ -111,8 +109,7 @@ gate(::GateName"Rz"; ϕ::Number) = [
   0 exp(im * ϕ)
 ]
 
-gate(::GateName"RZ"; kwargs...) = 
-  gate("Rz"; kwargs...)
+gate(::GateName"RZ"; kwargs...) = gate("Rz"; kwargs...)
 
 # Rotation around generic axis n̂
 function gate(::GateName"Rn"; θ::Real, ϕ::Real, λ::Real)
@@ -159,8 +156,7 @@ gate(::GateName"CRz"; ϕ::Real) = [
   0 0 0 exp(im * ϕ)
 ]
 
-gate(::GateName"CRZ"; kwargs...) = 
-  gate("CRz"; kwargs...)
+gate(::GateName"CRZ"; kwargs...) = gate("CRz"; kwargs...)
 
 function gate(::GateName"CRn"; θ::Real, ϕ::Real, λ::Real)
   return [
@@ -218,18 +214,13 @@ function gate(::GateName"Rxx"; ϕ::Number)
   ]
 end
 
-gate(::GateName"RXX"; kwargs...) = 
-  gate("Rxx"; kwargs...)
+gate(::GateName"RXX"; kwargs...) = gate("Rxx"; kwargs...)
 
-gate(::GateName"XX") = 
-  kron(gate("X"),gate("X"))
+gate(::GateName"XX") = kron(gate("X"), gate("X"))
 
-gate(::GateName"YY") = 
-  kron(gate("Y"),gate("Y"))
+gate(::GateName"YY") = kron(gate("Y"), gate("Y"))
 
-gate(::GateName"ZZ") = 
-  kron(gate("Z"),gate("Z"))
-
+gate(::GateName"ZZ") = kron(gate("Z"), gate("Z"))
 
 # TODO: Ising (YY) coupling gate
 #gate(::GateName"YY"; ϕ::Number) =
@@ -310,50 +301,50 @@ end
 # Random Haard unitary:
 # 
 # Reference: http://math.mit.edu/~edelman/publications/random_matrix_theory.pdf
-function gate(::GateName"randU", dims::Tuple = (2,);
-              eltype = ComplexF64,
-              random_matrix = randn(eltype, prod(dims), prod(dims)))
+function gate(
+  ::GateName"randU",
+  dims::Tuple=(2,);
+  eltype=ComplexF64,
+  random_matrix=randn(eltype, prod(dims), prod(dims)),
+)
   Q, _ = NDTensors.qr_positive(random_matrix)
   return Q
 end
 
-gate(::GateName"RandomUnitary", dims::Tuple = (2,); kwargs...) = 
-  gate("randU", dims; kwargs...)
-
+function gate(::GateName"RandomUnitary", dims::Tuple=(2,); kwargs...)
+  return gate("randU", dims; kwargs...)
+end
 
 #
 # qudit gates
 #
 
-function gate(::GateName"a", dims::Tuple = (2,))
+function gate(::GateName"a", dims::Tuple=(2,))
   @assert length(dims) == 1
   dim = dims[1]
   mat = zeros(dim, dim)
-  for k in 1:dim-1
-    mat[k,k+1] = √k
+  for k in 1:(dim - 1)
+    mat[k, k + 1] = √k
   end
   return mat
 end
 
-gate(::GateName"a†", dims::Tuple = (2,)) = 
-  Array(gate("a", dims)')
+gate(::GateName"a†", dims::Tuple=(2,)) = Array(gate("a", dims)')
 
-gate(::GateName"adag", dims::Tuple) = 
-  gate("a†", dims::Tuple)
+gate(::GateName"adag", dims::Tuple) = gate("a†", dims::Tuple)
 
-
-function gate(::GateName"a†a", dims::Tuple = (2,))
+function gate(::GateName"a†a", dims::Tuple=(2,))
   # single-qubit gate (i.e. chemical potential)
-  length(dims) == 1 && return gate("a†",dims) * gate("a", dims)
-  length(dims) == 2 && return kron(gate("a†", (dims[1],)),gate("a", (dims[2],)))
-  error("gate `a†a` only acting on one or two qubits")
+  length(dims) == 1 && return gate("a†", dims) * gate("a", dims)
+  length(dims) == 2 && return kron(gate("a†", (dims[1],)), gate("a", (dims[2],)))
+  return error("gate `a†a` only acting on one or two qubits")
 end
 
-function gate(::GateName"aa†", dims::Tuple = (2,))
+function gate(::GateName"aa†", dims::Tuple=(2,))
   # single-qubit gate (i.e. chemical potential)
-  length(dims) == 1 && return gate("a",dims) * gate("a†", dims)
-  length(dims) == 2 && return kron(gate("a", (dims[1],)),gate("a†", (dims[2],)))
-  error("gate `aa†` only acting on one or two qubits")
+  length(dims) == 1 && return gate("a", dims) * gate("a†", dims)
+  length(dims) == 2 && return kron(gate("a", (dims[1],)), gate("a†", (dims[2],)))
+  return error("gate `aa†` only acting on one or two qubits")
 end
 
 #
@@ -409,7 +400,6 @@ gate(s::String, args...; kwargs...) = gate(GateName(s), args...; kwargs...)
 # Version that accepts a dimension for the gate,
 gate(gn::GateName, dims::Tuple; kwargs...) = gate(gn; kwargs...)
 
-
 """
     combinegates(gn::GateName, s::Tuple; kwargs...)
 
@@ -418,14 +408,15 @@ Generate a gate (matrix) given a set of operations in the gatename string
 function combinegates(gn::GateName, s::Tuple; kwargs...)
   name = string(ITensors.name(gn))
   name = filter(x -> !isspace(x), name)
-  
+
   # first check for addition
   pluspos = findfirst("+", name)
   if !isnothing(pluspos)
     !isempty(kwargs) && error("Composition of parametric gates not allowed")
     gate1 = name[1:prevind(name, pluspos.start)]
     gate2 = name[nextind(name, pluspos.start):end]
-    return combinegates(GateName(gate1), dim.(s); kwargs...) + combinegates(GateName(gate2), dim.(s); kwargs...)
+    return combinegates(GateName(gate1), dim.(s); kwargs...) +
+           combinegates(GateName(gate2), dim.(s); kwargs...)
   end
   # next check for multiplication
   starpos = findfirst("*", name)
@@ -433,15 +424,13 @@ function combinegates(gn::GateName, s::Tuple; kwargs...)
     !isempty(kwargs) && error("Composition of parametric gates not allowed")
     gate1 = name[1:prevind(name, starpos.start)]
     gate2 = name[nextind(name, starpos.start):end]
-    return combinegates(GateName(gate1), dim.(s); kwargs...) * combinegates(GateName(gate2), dim.(s); kwargs...)
+    return combinegates(GateName(gate1), dim.(s); kwargs...) *
+           combinegates(GateName(gate2), dim.(s); kwargs...)
   end
   return gate(gn, dim.(s); kwargs...)
 end
 
-function gate(gn::GateName, s1::Index, ss::Index...; 
-              dag::Bool = false,
-              f = nothing,
-              kwargs...)
+function gate(gn::GateName, s1::Index, ss::Index...; dag::Bool=false, f=nothing, kwargs...)
   s = tuple(s1, ss...)
   rs = reverse(s)
   # temporary block on f. To be revised in gate system refactoring.
@@ -449,13 +438,13 @@ function gate(gn::GateName, s1::Index, ss::Index...;
 
   # generate dense gate
   g = combinegates(gn, s; kwargs...)
-  
+
   # conjugate the gate if `dag=true`
   g = dag ? Array(g') : g
-  
+
   # apply a function if passed
   g = !isnothing(f) ? f(g) : g
-    
+
   # generate itensor gate
   if ndims(g) == 1
     # TODO:
@@ -506,30 +495,30 @@ acting on sites `(site[1],site[2])`, with indices identical to a
 reference state `M` (`MPS` or `MPO`).
 """
 function gate(M::Union{MPS,MPO}, gatename::String, site::Tuple; kwargs...)
-  site_inds = [typeof(M) == MPS ? siteind(M, s) : firstind(M[s]; tags="Site", plev=0) for s in site]
+  site_inds = [
+    typeof(M) == MPS ? siteind(M, s) : firstind(M[s]; tags="Site", plev=0) for s in site
+  ]
   return gate(gatename, site_inds...; kwargs...)
 end
 
 #gate(M::Union{MPS,MPO}, gatedata::Tuple) = gate(M, gatedata...)
 
-gate(M::Union{MPS,MPO,ITensor}, gatedata::Tuple) =
-  gate(M,gatedata...)
+gate(M::Union{MPS,MPO,ITensor}, gatedata::Tuple) = gate(M, gatedata...)
 
-gate(M::Union{MPS,MPO,ITensor},
-     gatename::String,
-     sites::Union{Int, Tuple},
-     params::NamedTuple) =
-  gate(M, gatename, sites; params...)
+function gate(
+  M::Union{MPS,MPO,ITensor}, gatename::String, sites::Union{Int,Tuple}, params::NamedTuple
+)
+  return gate(M, gatename, sites; params...)
+end
 
-
-function gate(T::ITensor, gatename::String, site::Union{Int, Tuple}; kwargs...)
-  tensor_indices = vcat(inds(T, plev = 0)...)
+function gate(T::ITensor, gatename::String, site::Union{Int,Tuple}; kwargs...)
+  tensor_indices = vcat(inds(T; plev=0)...)
   tensor_tags = tags.(tensor_indices)
   X = [string.(tensor_tags[j]) for j in 1:length(tensor_tags)]
   sitenumber_position = findfirst(y -> y[1:2] == "n=", X[1])
   isnothing(sitenumber_position) && error("Qubit numbering not found")
-  Y = [parse(Int,X[j][sitenumber_position][3:end]) for j in 1:length(X)]
-  gateindices = [findfirst(x-> x == s, Y) for s in site] 
+  Y = [parse(Int, X[j][sitenumber_position][3:end]) for j in 1:length(X)]
+  gateindices = [findfirst(x -> x == s, Y) for s in site]
   site_inds = [tensor_indices[gateindex] for gateindex in gateindices]
   return gate(gatename, site_inds...; kwargs...)
 end
@@ -551,8 +540,11 @@ end
 
 randomparams(::GateName, args...; kwargs...) = NamedTuple()
 
-randomparams(::GateName"RandomUnitary", N::Int = 1; eltype = ComplexF64, rng = Random.GLOBAL_RNG) = 
-  (random_matrix = randn(rng, eltype, 1<<N, 1<<N),)
+function randomparams(
+  ::GateName"RandomUnitary", N::Int=1; eltype=ComplexF64, rng=Random.GLOBAL_RNG
+)
+  return (random_matrix=randn(rng, eltype, 1 << N, 1 << N),)
+end
 
 randomparams(s::AbstractString; kwargs...) = randomparams(GateName(s); kwargs...)
 

--- a/src/circuits/noise.jl
+++ b/src/circuits/noise.jl
@@ -1,84 +1,120 @@
 
-function gate(::GateName"pauli_channel", dims::Tuple = (2,); 
-              pauli_ops = ["Id","X","Y","Z"],
-              error_probabilities = prepend!(zeros(length(pauli_ops)^length(dims)-1),1))
+function gate(
+  ::GateName"pauli_channel",
+  dims::Tuple=(2,);
+  pauli_ops=["Id", "X", "Y", "Z"],
+  error_probabilities=prepend!(zeros(length(pauli_ops)^length(dims) - 1), 1),
+)
   @assert sum(error_probabilities) ≈ 1
   @assert all(dims .== 2)
   N = length(dims)
   length(error_probabilities) > (1 << 10) && error("Hilbert space too large")
   error_probabilities ./= sum(error_probabilities)
-  kraus = zeros(Complex{Float64},1<<N,1<<N,length(pauli_ops)^N)
-  basis = vec(reverse.(Iterators.product(fill(pauli_ops,N)...)|>collect))
-  for (k,ops) in enumerate(basis)
-    kraus[:,:,k] = √error_probabilities[k] * reduce(kron,gate.(ops)) 
+  kraus = zeros(Complex{Float64}, 1 << N, 1 << N, length(pauli_ops)^N)
+  basis = vec(reverse.(collect(Iterators.product(fill(pauli_ops, N)...))))
+  for (k, ops) in enumerate(basis)
+    kraus[:, :, k] = √error_probabilities[k] * reduce(kron, gate.(ops))
   end
   return kraus
 end
 
-gate(::GateName"bit_flip", dims::Tuple = (2,); p::Number) = 
-  gate("pauli_channel", dims; error_probabilities = prepend!(p/(2^length(dims)-1) * ones(2^length(dims)-1), 1-p), pauli_ops = ["Id","X"])
+function gate(::GateName"bit_flip", dims::Tuple=(2,); p::Number)
+  return gate(
+    "pauli_channel",
+    dims;
+    error_probabilities=prepend!(
+      p / (2^length(dims) - 1) * ones(2^length(dims) - 1), 1 - p
+    ),
+    pauli_ops=["Id", "X"],
+  )
+end
 
-gate(::GateName"phase_flip", dims::Tuple = (2,); p::Number) = 
-  gate("pauli_channel", dims; error_probabilities = prepend!(p/(2^length(dims)-1) * ones(2^length(dims)-1), 1-p), pauli_ops = ["Id","Z"])
+function gate(::GateName"phase_flip", dims::Tuple=(2,); p::Number)
+  return gate(
+    "pauli_channel",
+    dims;
+    error_probabilities=prepend!(
+      p / (2^length(dims) - 1) * ones(2^length(dims) - 1), 1 - p
+    ),
+    pauli_ops=["Id", "Z"],
+  )
+end
 
-function gate(::GateName"AD", dims::Tuple = (2,); γ::Real)
+function gate(::GateName"AD", dims::Tuple=(2,); γ::Real)
   N = length(dims)
   @assert all(dims .== 2)
-  kraus = zeros(2,2,2)
-  kraus[:,:,1] = [1 0
-                  0 sqrt(1-γ)]
-  kraus[:,:,2] = [0 sqrt(γ)
-                  0 0]
-  N == 1 && return kraus 
-  k1 = kraus[:,:,1]
-  k2 = kraus[:,:,2]
-  T = vec(Iterators.product(fill([k1,k2],N)...)|>collect)
-  K = zeros(Float64,1<<N,1<<N,1<<N)
-  for x in 1:1<<N
-    K[:,:,x] = reduce(kron,T[x]) 
+  kraus = zeros(2, 2, 2)
+  kraus[:, :, 1] = [
+    1 0
+    0 sqrt(1 - γ)
+  ]
+  kraus[:, :, 2] = [
+    0 sqrt(γ)
+    0 0
+  ]
+  N == 1 && return kraus
+  k1 = kraus[:, :, 1]
+  k2 = kraus[:, :, 2]
+  T = vec(collect(Iterators.product(fill([k1, k2], N)...)))
+  K = zeros(Float64, 1 << N, 1 << N, 1 << N)
+  for x in 1:(1 << N)
+    K[:, :, x] = reduce(kron, T[x])
   end
   return K
 end
 #
 # To accept the gate name "amplitude_damping"
-gate(::GateName"amplitude_damping", dims::Tuple = (2,); kwargs...) = gate("AD", dims; kwargs...)
+function gate(::GateName"amplitude_damping", dims::Tuple=(2,); kwargs...)
+  return gate("AD", dims; kwargs...)
+end
 
-function gate(::GateName"PD", dims::Tuple = (2,); γ::Real)
+function gate(::GateName"PD", dims::Tuple=(2,); γ::Real)
   N = length(dims)
   @assert all(dims .== 2)
-  kraus = zeros(2,2,2)
-  kraus[:,:,1] = [1 0
-                  0 sqrt(1-γ)]
-  kraus[:,:,2] = [0 0
-                  0 sqrt(γ)]
+  kraus = zeros(2, 2, 2)
+  kraus[:, :, 1] = [
+    1 0
+    0 sqrt(1 - γ)
+  ]
+  kraus[:, :, 2] = [
+    0 0
+    0 sqrt(γ)
+  ]
 
-  N == 1 && return kraus 
-  k1 = kraus[:,:,1]
-  k2 = kraus[:,:,2]
-  T = vec(Iterators.product(fill([k1,k2],N)...)|>collect)
-  K = zeros(Float64,1<<N,1<<N,1<<N)
-  for x in 1:1<<N
-    K[:,:,x] = reduce(kron,T[x]) 
+  N == 1 && return kraus
+  k1 = kraus[:, :, 1]
+  k2 = kraus[:, :, 2]
+  T = vec(collect(Iterators.product(fill([k1, k2], N)...)))
+  K = zeros(Float64, 1 << N, 1 << N, 1 << N)
+  for x in 1:(1 << N)
+    K[:, :, x] = reduce(kron, T[x])
   end
   return K
 end
 
 # To accept the gate name "phase_damping"
-gate(::GateName"phase_damping", dims::Tuple = (2,); kwargs...) = gate("PD", dims; kwargs...)
+gate(::GateName"phase_damping", dims::Tuple=(2,); kwargs...) = gate("PD", dims; kwargs...)
 #
 # To accept the gate name "dephasing"
-gate(::GateName"dephasing", dims::Tuple = (2,); kwargs...) = gate("PD", dims; kwargs...)
+gate(::GateName"dephasing", dims::Tuple=(2,); kwargs...) = gate("PD", dims; kwargs...)
 
 # make general n-qubit
-gate(::GateName"DEP", dims::Tuple = (2,); p::Number) =
-  gate("pauli_channel", dims; error_probabilities = prepend!(p/(4^length(dims)-1) * ones(4^length(dims)-1), 1-p), pauli_ops = ["Id","X","Y","Z"])
+function gate(::GateName"DEP", dims::Tuple=(2,); p::Number)
+  return gate(
+    "pauli_channel",
+    dims;
+    error_probabilities=prepend!(
+      p / (4^length(dims) - 1) * ones(4^length(dims) - 1), 1 - p
+    ),
+    pauli_ops=["Id", "X", "Y", "Z"],
+  )
+end
 
 # To accept the gate name "depolarizing"
-gate(::GateName"depolarizing", dims::Tuple = (2,); kwargs...) = 
-  gate("DEP", dims; kwargs...)
+gate(::GateName"depolarizing", dims::Tuple=(2,); kwargs...) = gate("DEP", dims; kwargs...)
 
-function insertnoise(circuit::Vector{<:Vector{<:Any}}, noisemodel::Tuple; gate = nothing)#idlenoise::Bool = false) 
-  max_g_size = maxgatesize(circuit) 
+function insertnoise(circuit::Vector{<:Vector{<:Any}}, noisemodel::Tuple; gate=nothing)#idlenoise::Bool = false) 
+  max_g_size = maxgatesize(circuit)
 
   # single noise model for all
   if noisemodel[1] isa String
@@ -97,8 +133,13 @@ function insertnoise(circuit::Vector{<:Vector{<:Any}}, noisemodel::Tuple; gate =
     noisylayer = []
     for g in layer
       push!(noisylayer, g)
-      applynoise = (isnothing(gate) ? true : 
-                    gate isa String ? g[1] == gate : g[1] in gate)
+      applynoise = (if isnothing(gate)
+        true
+      elseif gate isa String
+        g[1] == gate
+      else
+        g[1] in gate
+      end)
       #@applytogate = gate isa String ? g[1] == gate : g[1] in gate
       #if isnothing(gate) || applytogate
       if applynoise
@@ -106,28 +147,31 @@ function insertnoise(circuit::Vector{<:Vector{<:Any}}, noisemodel::Tuple; gate =
         # n-qubit gate
         if nq isa Tuple
           gatenoiseindex = findfirst(x -> x == length(nq), first.(noisemodel))
-          isnothing(gatenoiseindex) && error("Noise model not defined for $(length(nq))-qubit gates!")
+          isnothing(gatenoiseindex) &&
+            error("Noise model not defined for $(length(nq))-qubit gates!")
           gatenoise = last(noisemodel[gatenoiseindex])
           # Check whether the n-qubit Kraus channel has been defined
           # n -qubit Kraus operator
-          noisecheck = PastaQ.gate(gatenoise[1], Tuple(repeat([2], length(nq))); gatenoise[2]...)
+          noisecheck = PastaQ.gate(
+            gatenoise[1], Tuple(repeat([2], length(nq))); gatenoise[2]...
+          )
           # if the single-qubit copy is return, use productnoise, and throw a warning
-          if size(noisecheck,1) < 1<<length(nq)
+          if size(noisecheck, 1) < 1 << length(nq)
             @warn "$(length(nq))-qubit Kraus operators for the $(gatenoise[1]) noise not defined. Applying tensor-product noise instead.\n"
             # tensor-product noise
             for q in nq
-              push!(noisylayer,(gatenoise[1], q, gatenoise[2]))
+              push!(noisylayer, (gatenoise[1], q, gatenoise[2]))
             end
           else
             # correlated n-qubit noise
-            push!(noisylayer,(gatenoise[1], nq, gatenoise[2]))
+            push!(noisylayer, (gatenoise[1], nq, gatenoise[2]))
           end
-        # 1-qubit gate
+          # 1-qubit gate
         else
           gatenoiseindex = findfirst(x -> x == 1, first.(noisemodel))
           isnothing(gatenoiseindex) && error("Noise model not defined for 1-qubit gates!")
           gatenoise = last(noisemodel[gatenoiseindex])
-          push!(noisylayer, (gatenoise[1], nq, gatenoise[2]))  
+          push!(noisylayer, (gatenoise[1], nq, gatenoise[2]))
         end
       end
     end
@@ -146,8 +190,9 @@ function insertnoise(circuit::Vector{<:Vector{<:Any}}, noisemodel::Tuple; gate =
   return noisycircuit
 end
 
-insertnoise(circuit::Vector{<:Any}, noisemodel::Tuple; kwargs...) = 
-  insertnoise([circuit], noisemodel; kwargs...)[1]
+function insertnoise(circuit::Vector{<:Any}, noisemodel::Tuple; kwargs...)
+  return insertnoise([circuit], noisemodel; kwargs...)[1]
+end
 
 function maxgatesize(circuit::Vector{<:Vector{<:Any}})
   maxsize = 0
@@ -159,6 +204,4 @@ function maxgatesize(circuit::Vector{<:Vector{<:Any}})
   return maxsize
 end
 
-maxgatesize(circuit::Vector{<:Any}) = 
-  maxgatesize([circuit])
- 
+maxgatesize(circuit::Vector{<:Any}) = maxgatesize([circuit])

--- a/src/circuits/runcircuit.jl
+++ b/src/circuits/runcircuit.jl
@@ -10,7 +10,7 @@ added to each gate as a tensor with an extra (Kraus) index.
 function buildcircuit(
   M::Union{MPS,MPO,ITensor},
   circuit::Union{Tuple,Vector{<:Any}};
-  noise::Union{Nothing, Tuple, NamedTuple} = nothing
+  noise::Union{Nothing,Tuple,NamedTuple}=nothing,
 )
   circuit_tensors = ITensor[]
   if circuit isa Tuple
@@ -28,7 +28,6 @@ end
 function buildcircuit(M::Union{MPS,MPO,ITensor}, circuit::Vector{Vector{<:Any}}; kwargs...)
   return buildcircuit(M, vcat(circuit...); kwargs...)
 end
-
 
 """
 --------------------------------------------------------------------------------
@@ -169,20 +168,22 @@ If an `Observer` is provided as input, and `circuit` is made out of a sequence
 of layers of gates, performs a measurement of the observables contained in
 Observer, after the application of each layer.
 """
-runcircuit(M::Union{MPS, MPO,ITensor}, circuit::Union{Tuple,Vector{<:Any}};
-           noise = nothing, kwargs...) = 
-  runcircuit(M, buildcircuit(M, circuit; noise = noise); kwargs...)
+function runcircuit(
+  M::Union{MPS,MPO,ITensor}, circuit::Union{Tuple,Vector{<:Any}}; noise=nothing, kwargs...
+)
+  return runcircuit(M, buildcircuit(M, circuit; noise=noise); kwargs...)
+end
 
 function runcircuit(
   M::Union{MPS,MPO},
   circuit::Vector{<:Vector{<:Any}};
   (observer!)=nothing,
   move_sites_back_before_measurements::Bool=false,
-  noise = nothing,
-  outputlevel = 1,
-  outputpath = nothing,
-  savestate = false,
-  print_metrics = [],
+  noise=nothing,
+  outputlevel=1,
+  outputpath=nothing,
+  savestate=false,
+  print_metrics=[],
   kwargs...,
 )
 
@@ -204,11 +205,15 @@ function runcircuit(
   for l in 1:length(circuit)
     layer = circuit[l]
     t = @elapsed begin
-      M = runcircuit(M, layer; noise = noise,
-                     move_sites_back=move_sites_back_before_measurements,
-                     kwargs...)
+      M = runcircuit(
+        M,
+        layer;
+        noise=noise,
+        move_sites_back=move_sites_back_before_measurements,
+        kwargs...,
+      )
       if !isnothing(observer!)
-        update!(observer!, M; sites = s)
+        update!(observer!, M; sites=s)
       end
     end
     if outputlevel ≥ 1
@@ -263,38 +268,36 @@ The starting state is generated automatically based on the flags `process`, `noi
    `Λ = ε⊗1̂(|ξ⟩⟨ξ|)`, where `|ξ⟩= ⨂ⱼ |00⟩ⱼ+|11⟩ⱼ`, approximated by a MPO with 4 site indices,
    two for the input and two for the output Hilbert space of the quantum channel.
 """
-function runcircuit(sites::Vector{<:Index}, 
-                    circuit::Union{Tuple,Vector{<:Any},Vector{Vector{<:Any}}};
-                    process::Bool = false, noise = nothing,
-                    full_representation::Bool = false,
-                    kwargs...)
-  
-  
+function runcircuit(
+  sites::Vector{<:Index},
+  circuit::Union{Tuple,Vector{<:Any},Vector{Vector{<:Any}}};
+  process::Bool=false,
+  noise=nothing,
+  full_representation::Bool=false,
+  kwargs...,
+)
+
   # Unitary operator for the circuit
-  if process && isnothing(noise) 
+  if process && isnothing(noise)
     U₀ = full_representation ? prod(productoperator(sites)) : productoperator(sites)
-    return runcircuit(U₀, circuit; 
-                      noise = nothing, 
-                      apply_dag = false, 
-                      kwargs...) 
-  end 
+    return runcircuit(U₀, circuit; noise=nothing, apply_dag=false, kwargs...)
+  end
   # Choi matrix
   if process && !isnothing(noise)
-    return choimatrix(sites, circuit; 
-                      noise = noise, 
-                      full_representation = full_representation,
-                      kwargs...)
+    return choimatrix(
+      sites, circuit; noise=noise, full_representation=full_representation, kwargs...
+    )
   end
-  
-  M₀ = full_representation ? prod(productstate(sites)) : productstate(sites) 
-  return runcircuit(M₀, circuit; noise = noise, kwargs...) 
+
+  M₀ = full_representation ? prod(productstate(sites)) : productstate(sites)
+  return runcircuit(M₀, circuit; noise=noise, kwargs...)
 end
 
-runcircuit(N::Int, circuit::Any; kwargs...) = 
-  runcircuit(siteinds("Qubit", N), circuit; kwargs...)
+function runcircuit(N::Int, circuit::Any; kwargs...)
+  return runcircuit(siteinds("Qubit", N), circuit; kwargs...)
+end
 
-runcircuit(circuit::Any; kwargs...) = 
-  runcircuit(nqubits(circuit), circuit; kwargs...)
+runcircuit(circuit::Any; kwargs...) = runcircuit(nqubits(circuit), circuit; kwargs...)
 
 """
 --------------------------------------------------------------------------------
@@ -310,10 +313,12 @@ runcircuit(circuit::Any; kwargs...) =
 Apply the circuit to a ITensor from a list of tensors.
 """
 
-function runcircuit(T::ITensor, circuit_tensors::Vector{<:ITensor}; apply_dag = nothing, kwargs...)
+function runcircuit(
+  T::ITensor, circuit_tensors::Vector{<:ITensor}; apply_dag=nothing, kwargs...
+)
   # Check if gate_tensors contains Kraus operators
   inds_sizes = [length(inds(g)) for g in circuit_tensors]
-  noiseflag = any(x -> x % 2 == 1 , inds_sizes)
+  noiseflag = any(x -> x % 2 == 1, inds_sizes)
 
   if apply_dag == false && noiseflag == true
     error("noise simulation requires apply_dag=true")
@@ -324,25 +329,24 @@ function runcircuit(T::ITensor, circuit_tensors::Vector{<:ITensor}; apply_dag = 
     if noiseflag
       T = is_operator(T) ? T : prime(T, "Site") * dag(T)
       # ρ -> ε(ρ) (MPO -> MPO, conjugate evolution)
-      return apply(circuit_tensors, T; apply_dag = true)
-    # Pure state evolution
+      return apply(circuit_tensors, T; apply_dag=true)
+      # Pure state evolution
     else
       # |ψ⟩ -> U |ψ⟩ (MPS -> MPS)
       #  ρ  -> U ρ U† (MPO -> MPO, conjugate evolution)
       if !is_operator(T)
         return apply(circuit_tensors, T)
       else
-        return apply(circuit_tensors, T; apply_dag = true)
+        return apply(circuit_tensors, T; apply_dag=true)
       end
     end
-  # Custom mode (apply_dag = true / false)
+    # Custom mode (apply_dag = true / false)
   else
-    Tc = apply(circuit_tensors, T; apply_dag = apply_dag)
+    Tc = apply(circuit_tensors, T; apply_dag=apply_dag)
     !is_operator(T) && apply_dag && return prime(Tc, "Site") * dag(Tc)
     return Tc
   end
 end
-
 
 """
 --------------------------------------------------------------------------------
@@ -358,31 +362,39 @@ Compute the Choi matrix `Λ  = ε ⊗ 1̂(|ξ⟩⟨ξ|)`, where `|ξ⟩= ⨂ⱼ 
 and `ε`` is a quantum channel built out of a set of quantum gates and 
 a local noise model. Returns a MPO with `N` tensor having 4 sites indices. 
 """
-choimatrix(circuit::Vector{<:Any}; kwargs...) = 
-  choimatrix(nqubits(circuit), circuit; kwargs...)
+function choimatrix(circuit::Vector{<:Any}; kwargs...)
+  return choimatrix(nqubits(circuit), circuit; kwargs...)
+end
 
-choimatrix(sites::Union{Int, Vector{<:Index}}, args...; kwargs...) = 
-  choimatrix(unitary_mpo_to_choi_mpo(productoperator(sites)), args...; kwargs...) 
+function choimatrix(sites::Union{Int,Vector{<:Index}}, args...; kwargs...)
+  return choimatrix(unitary_mpo_to_choi_mpo(productoperator(sites)), args...; kwargs...)
+end
 
-function choimatrix(Λ0::MPO, circuit::Vector{<:Any};
-                    noise = nothing, cutoff = 1e-15, maxdim = 10000,
-                    svd_alg = "divide_and_conquer", full_representation = false)
+function choimatrix(
+  Λ0::MPO,
+  circuit::Vector{<:Any};
+  noise=nothing,
+  cutoff=1e-15,
+  maxdim=10000,
+  svd_alg="divide_and_conquer",
+  full_representation=false,
+)
   N = length(Λ0)
   if isnothing(noise)
     error("choi matrix requires noise")
   end
   # if circuit has layer structure, transform to vectorized circuit
   circuit = (circuit isa Vector{<:Vector} ? vcat(circuit...) : circuit)
-  
+
   # TODO: simplify by building the circuit directly from the Choi MPO.
-  s = [firstind(Λ0[j], tags = "Output") for j in 1:length(Λ0)]
+  s = [firstind(Λ0[j]; tags="Output") for j in 1:length(Λ0)]
   compiler = productoperator(s)
-  prime!(compiler,-1,tags = "Qubit") 
-  circuit_tensors = buildcircuit(compiler, circuit; noise = noise)
+  prime!(compiler, -1; tags="Qubit")
+  circuit_tensors = buildcircuit(compiler, circuit; noise=noise)
 
   # contract to compute the Choi matrix
   Λ₀ = full_representation ? prod(Λ0) : Λ0
-  return runcircuit(Λ₀, circuit_tensors; apply_dag = true, cutoff = cutoff,
-                    maxdim = maxdim, svd_alg = svd_alg)
+  return runcircuit(
+    Λ₀, circuit_tensors; apply_dag=true, cutoff=cutoff, maxdim=maxdim, svd_alg=svd_alg
+  )
 end
-

--- a/src/circuits/trottersuzuki.jl
+++ b/src/circuits/trottersuzuki.jl
@@ -1,11 +1,10 @@
-function getsites(g) 
+function getsites(g)
   x = filter(x -> x isa Tuple, g)
   isempty(x) && return x
   return only(x)
 end
 
-sort_gates_by(g) = 
-  TupleTools.sort(getsites(g))
+sort_gates_by(g) = TupleTools.sort(getsites(g))
 
 function sort_gates_lt(g1, g2)
   if length(g1) ≠ length(g2)
@@ -14,14 +13,12 @@ function sort_gates_lt(g1, g2)
   return g1 < g2
 end
 
-sort_gates(gates) = 
-  sort(gates; by=sort_gates_by, lt=sort_gates_lt)
-
+sort_gates(gates) = sort(gates; by=sort_gates_by, lt=sort_gates_lt)
 
 function trotter1(H::OpSum, δτ::Number)
   onequbitgates = Tuple[]
   multiqubitgates = Tuple[]
-  
+
   n = 1
   for k in 1:length(H)
     coupling = ITensors.coef(H[k])
@@ -33,24 +30,26 @@ function trotter1(H::OpSum, δτ::Number)
 
     # single-qubit gate
     if length(support) == 1
-      g = (localop, support[1], (params..., f = x -> exp(-δτ * coupling * x),)) 
+      g = (localop, support[1], (params..., f=x -> exp(-δτ * coupling * x)))
       push!(onequbitgates, g)
       n = support[1] ≥ n ? support[1] : n
-    # multi-qubit gate
+      # multi-qubit gate
     else
-      g = (localop, support, (params..., f = x -> exp(-δτ * coupling * x),)) 
+      g = (localop, support, (params..., f=x -> exp(-δτ * coupling * x)))
       push!(multiqubitgates, g)
       n = maximum(support) ≥ n ? maximum(support) : n
     end
   end
-  
+
   sorted_multi_qubit = sort_gates(multiqubitgates)
   sorted_one_qubit = onequbitgates[sortperm([s[2] for s in onequbitgates])]
-  
+
   # TODO: simplify this unison sorting loop
   tebd1 = Tuple[]
-  g1_counter = 1; nmq = length(sorted_multi_qubit)
-  gm_counter = 1; n1q = length(onequbitgates)
+  g1_counter = 1
+  nmq = length(sorted_multi_qubit)
+  gm_counter = 1
+  n1q = length(onequbitgates)
   for j in 1:n
     while (gm_counter ≤ nmq) && any(sorted_multi_qubit[gm_counter][2] .== j)
       push!(tebd1, sorted_multi_qubit[gm_counter])
@@ -65,30 +64,28 @@ function trotter1(H::OpSum, δτ::Number)
   return tebd1
 end
 
-
-
 """
     trotter2(H::OpSum; δt::Float64=0.1, δτ=im*δt)
 
 Generate a single layer of gates for one step of 2nd order TEBD.
 """
 function trotter2(H::OpSum, δτ::Number)
-  tebd1 = trotter1(H, δτ/2)
+  tebd1 = trotter1(H, δτ / 2)
   tebd2 = copy(tebd1)
   append!(tebd2, reverse(tebd1))
   return tebd2
 end
 
 function trotter4(H::OpSum, δτ::Number)
-  δτ1 = δτ / (4 - 4^(1/3)) 
+  δτ1 = δτ / (4 - 4^(1 / 3))
   δτ2 = δτ - 4 * δτ1
-  
+
   tebd2_δ1 = trotter2(H, δτ1)
   tebd2_δ2 = trotter2(H, δτ2)
-  
-  tebd4 = vcat(tebd2_δ1,tebd2_δ1)
+
+  tebd4 = vcat(tebd2_δ1, tebd2_δ1)
   append!(tebd4, tebd2_δ2)
-  append!(tebd4, vcat(tebd2_δ1,tebd2_δ1))
+  append!(tebd4, vcat(tebd2_δ1, tebd2_δ1))
   return tebd4
 end
 
@@ -97,64 +94,89 @@ end
 
 Generate a single layer of gates for one step of TEBD.
 """
-function trotterlayer(H::OpSum, δτ::Number; order::Int = 2)
-  order == 1 && return trotter1(H, δτ) 
-  order == 2 && return trotter2(H, δτ) 
-  error("Automated Trotter circuits with order > 2 not yet implemented")
+function trotterlayer(H::OpSum, δτ::Number; order::Int=2)
+  order == 1 && return trotter1(H, δτ)
+  order == 2 && return trotter2(H, δτ)
+  return error("Automated Trotter circuits with order > 2 not yet implemented")
   # TODO: understand weird behaviour of trotter4
   #order == 4 && return trotter4(H, δτ) 
   #error("Automated Trotter circuits with order > 2 not yet implemented")
 end
 
+trottercircuit(H; kwargs...) = _trottercircuit(H, get_times(; kwargs...); kwargs...)
 
-trottercircuit(H; kwargs...) = 
-  _trottercircuit(H, get_times(;kwargs...); kwargs...)
-
-function _trottercircuit(H::Vector{<:OpSum}, τs::Vector; order::Int = 2, layered::Bool = true, kwargs...)
-  @assert length(H) == (length(τs) -1) || length(H) == length(τs)
+function _trottercircuit(
+  H::Vector{<:OpSum}, τs::Vector; order::Int=2, layered::Bool=true, kwargs...
+)
+  @assert length(H) == (length(τs) - 1) || length(H) == length(τs)
   δτs = diff(τs)
-  circuit = [trotterlayer(H[t], δτs[t]; order = order) for t in 1:length(δτs)] 
+  circuit = [trotterlayer(H[t], δτs[t]; order=order) for t in 1:length(δτs)]
   layered && return circuit
   return vcat(circuit...)
 end
 
-_trottercircuit(H::OpSum, τs::Vector; kwargs...) = 
-  _trottercircuit(repeat([H], length(τs)-1), τs; kwargs...) 
+function _trottercircuit(H::OpSum, τs::Vector; kwargs...)
+  return _trottercircuit(repeat([H], length(τs) - 1), τs; kwargs...)
+end
 
-get_times(; δt=nothing, δτ=nothing, t=nothing, τ=nothing, ts=nothing, τs=nothing, kwargs...) = get_times(δt, δτ, t, τ, ts, τs)
+function get_times(;
+  δt=nothing, δτ=nothing, t=nothing, τ=nothing, ts=nothing, τs=nothing, kwargs...
+)
+  return get_times(δt, δτ, t, τ, ts, τs)
+end
 
-
-get_times(δt::Nothing, δτ::Nothing, t::Nothing, τ::Nothing, ts::Vector,  τs::Nothing)   = im .* ts 
-get_times(δt::Nothing, δτ::Nothing, t::Nothing, τ::Nothing, ts::Nothing, τs::Vector)    = τs 
+function get_times(
+  δt::Nothing, δτ::Nothing, t::Nothing, τ::Nothing, ts::Vector, τs::Nothing
+)
+  return im .* ts
+end
+get_times(δt::Nothing, δτ::Nothing, t::Nothing, τ::Nothing, ts::Nothing, τs::Vector) = τs
 
 function get_times(δt::Nothing, δτ::Number, t::Nothing, τ::Number, ts::Nothing, τs::Nothing)
   depth = abs(τ / δτ)
-  (depth-Int(floor(depth)) > 1e-5) && @warn "Incommensurate Trotter step!"
-  return collect(0.0:δτ:τ) 
+  (depth - Int(floor(depth)) > 1e-5) && @warn "Incommensurate Trotter step!"
+  return collect(0.0:δτ:τ)
 end
 
-get_times(δt::Number, δτ::Nothing, t::Number, τ::Nothing, ts::Nothing, τs::Nothing) =
-  im .* get_times(δτ, δt, τ, t, ts, τs)
+function get_times(δt::Number, δτ::Nothing, t::Number, τ::Nothing, ts::Nothing, τs::Nothing)
+  return im .* get_times(δτ, δt, τ, t, ts, τs)
+end
 
-get_times(δt::Nothing, δτ::Nothing, t::Nothing, τ::Nothing, ts::AbstractRange, τs::Nothing)       = 
-  get_times(δt, δτ, t, τ, collect(ts), τs) 
+function get_times(
+  δt::Nothing, δτ::Nothing, t::Nothing, τ::Nothing, ts::AbstractRange, τs::Nothing
+)
+  return get_times(δt, δτ, t, τ, collect(ts), τs)
+end
 
-get_times(δt::Nothing, δτ::Nothing, t::Nothing, τ::Nothing, ts::Nothing,       τs::AbstractRange) = 
-  get_times(δt, δτ, t, τ, ts, collect(τs))
+function get_times(
+  δt::Nothing, δτ::Nothing, t::Nothing, τ::Nothing, ts::Nothing, τs::AbstractRange
+)
+  return get_times(δt, δτ, t, τ, ts, collect(τs))
+end
 
+function get_times(
+  δt::Number, δτ::Nothing, t::Nothing, τ::Nothing, ts::Nothing, τs::Nothing
+)
+  return error("Total time `t` not set.")
+end
 
-get_times(δt::Number,  δτ::Nothing, t::Nothing, τ::Nothing, ts::Nothing, τs::Nothing)   =
-  error("Total time `t` not set.")
+function get_times(
+  δt::Nothing, δτ::Number, t::Nothing, τ::Nothing, ts::Nothing, τs::Nothing
+)
+  return error("Total imaginary time `τ` not set")
+end
 
-get_times(δt::Nothing, δτ::Number,  t::Nothing, τ::Nothing, ts::Nothing, τs::Nothing)   =
-  error("Total imaginary time `τ` not set")
+function get_times(
+  δt::Nothing, δτ::Nothing, t::Number, τ::Nothing, ts::Nothing, τs::Nothing
+)
+  return error("Trotter step `δt` not set.")
+end
 
-get_times(δt::Nothing,  δτ::Nothing, t::Number, τ::Nothing, ts::Nothing, τs::Nothing)   =
-  error("Trotter step `δt` not set.")
-
-get_times(δt::Nothing,  δτ::Nothing, t::Nothing, τ::Number, ts::Nothing, τs::Nothing)   =
-  error("Imaginary Trotter step `δτ` not set.")
-
+function get_times(
+  δt::Nothing, δτ::Nothing, t::Nothing, τ::Number, ts::Nothing, τs::Nothing
+)
+  return error("Imaginary Trotter step `δτ` not set.")
+end
 
 #get_times(; δt=nothing, δτ=nothing, t=nothing, τ=nothing, ts=nothing, τs=nothing, kwargs...) = get_times(δt, δτ, t, τ, ts, τs)
 #

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -96,4 +96,3 @@ function qubits(sites::Vector{<:Index}, states::Vector{String}; mixed::Bool=fals
   mixed && return MPO(ψ)
   return ψ
 end
-

--- a/src/distances.jl
+++ b/src/distances.jl
@@ -11,7 +11,6 @@ ITensors.inner(ρ::MPO, σ::LPDO{MPO}) = inner(ρ, MPO(σ))
 
 ITensors.inner(ρ::MPO, σ::LPDO{MPS}) = inner(σ.X, ρ, σ.X)
 
-
 """
     fidelity(ψ::MPS, ϕ::MPS; kwargs...)
 
@@ -50,7 +49,6 @@ end
 
 fidelity(ρ::MPO, ψ::MPS; kwargs...) = fidelity(ψ, ρ)
 
-
 """
     fidelity(Ψ::MPS, ϱ::LPDO{MPO}; cutoff::Float64 = 1e-15)
     fidelity(ϱ::LPDO{MPO}, ψ::MPS; kwargs...)
@@ -60,17 +58,15 @@ LPDO density operator.
 
 F = ⟨ψ|ϱ|ψ⟩=|X†|ψ⟩|²
 """
-function fidelity(Ψ::MPS, ϱ::LPDO{MPO}; cutoff::Float64 = 1e-15)
+function fidelity(Ψ::MPS, ϱ::LPDO{MPO}; cutoff::Float64=1e-15)
   # TODO: fix exponential scaling
   #proj = bra(ϱ) * Ψ
-  proj = *(bra(ϱ), Ψ; cutoff = cutoff)
+  proj = *(bra(ϱ), Ψ; cutoff=cutoff)
   K = abs2(norm(Ψ)) * tr(ϱ)
   return inner(proj, proj) / K
 end
 
-fidelity(ϱ::LPDO{MPO}, ψ::MPS; kwargs...) = 
-  fidelity(ψ, ϱ; kwargs...)
-          
+fidelity(ϱ::LPDO{MPO}, ψ::MPS; kwargs...) = fidelity(ψ, ϱ; kwargs...)
 
 struct Choi{T}
   X::T
@@ -81,10 +77,10 @@ end
 
 Fidelity between two MPOs. If any is a Choi matrix, wrap them with the Choi type.
 """
-function fidelity(A::MPO, B::MPO; process::Bool = false, cutoff::Float64 = 1e-15)
+function fidelity(A::MPO, B::MPO; process::Bool=false, cutoff::Float64=1e-15)
   a = ischoi(A) ? Choi(A) : A
   b = ischoi(B) ? Choi(B) : B
-  return _fidelity(a, b; process = process, cutoff = cutoff)
+  return _fidelity(a, b; process=process, cutoff=cutoff)
 end
 
 """
@@ -93,19 +89,20 @@ end
 
 [INTERNAL]: process fidelity between a Choi matrix and a unitary MPO.
 """
-_fidelity(A::Choi, B::MPO; cutoff::Float64 = 1e-15, kwargs...) = 
-  fidelity(A.X, unitary_mpo_to_choi_mps(B); cutoff = cutoff)
+function _fidelity(A::Choi, B::MPO; cutoff::Float64=1e-15, kwargs...)
+  return fidelity(A.X, unitary_mpo_to_choi_mps(B); cutoff=cutoff)
+end
 
-_fidelity(A::MPO, B::Choi; cutoff::Float64 = 1e-15, kwargs...) = 
-  _fidelity(B, A; cutoff = cutoff)
+function _fidelity(A::MPO, B::Choi; cutoff::Float64=1e-15, kwargs...)
+  return _fidelity(B, A; cutoff=cutoff)
+end
 
 """
     _fidelity(A::Choi, B::Choi; kwargs...)
 
 [INTERNAL]: process fidelity between two Choi matrices
 """
-_fidelity(A::Choi, B::Choi; kwargs...) = 
-  fidelity(prod(A.X), prod(B.X); kwargs...)
+_fidelity(A::Choi, B::Choi; kwargs...) = fidelity(prod(A.X), prod(B.X); kwargs...)
 
 """
     _fidelity(A::MPO, B::MPO; process::Bool = false, kwargs...)
@@ -113,7 +110,7 @@ _fidelity(A::Choi, B::Choi; kwargs...) =
 [INTERNAL]: fidelity between two MPOs, which could be either two unitary MPOs
 or two density matrices.
 """
-function _fidelity(A::MPO, B::MPO; process::Bool = false, kwargs...)
+function _fidelity(A::MPO, B::MPO; process::Bool=false, kwargs...)
   # TODO: sub after implementing MPDO
   #A = !process ? MPDO(A) : A
   #B = !process ? MPDO(B) : B
@@ -135,40 +132,36 @@ end
 
 [INTERNAL]: state fidelity between two density matrices
 """
-__fidelity(A::MPO, B::MPO; kwargs...) = 
-  fidelity(prod(A), prod(B))
+__fidelity(A::MPO, B::MPO; kwargs...) = fidelity(prod(A), prod(B))
 
 """
     __fidelity(A::MPS, B::MPS; kwargs...)
 [INTERNAL]: process fidelity between two unitary MPOs
 """
-__fidelity(A::MPS, B::MPS; kwargs...) = 
-  fidelity(A, B)
-
+__fidelity(A::MPS, B::MPS; kwargs...) = fidelity(A, B)
 
 """
     fidelity(A::MPO, B::LPDO{MPO}; process::Bool=false, cutoff::Float64 = 1e-15)
 
 Fidelity between a MPO and a LPDO. Wrap the MPO in the Choi if so.
 """
-function fidelity(A::MPO, B::LPDO{MPO}; process::Bool=false, cutoff::Float64 = 1e-15)
+function fidelity(A::MPO, B::LPDO{MPO}; process::Bool=false, cutoff::Float64=1e-15)
   A = ischoi(A) ? Choi(A) : A
-  return _fidelity(A, B; process = process, cutoff = cutoff)
+  return _fidelity(A, B; process=process, cutoff=cutoff)
 end
 
-fidelity(A::LPDO{MPO}, B::MPO; kwargs...) = 
-  fidelity(B,A; kwargs...)
+fidelity(A::LPDO{MPO}, B::MPO; kwargs...) = fidelity(B, A; kwargs...)
 
 """
     _fidelity(A::Choi, B::LPDO{MPO}; process::Bool = false, kwargs...)
 
 [INTERNAL]: process fidelity between a Choi MPO and a Choi LPDO
 """
-_fidelity(A::Choi, B::LPDO{MPO}; process::Bool = false, kwargs...) = 
-  fidelity(A.X, MPO(B); kwargs...)
+function _fidelity(A::Choi, B::LPDO{MPO}; process::Bool=false, kwargs...)
+  return fidelity(A.X, MPO(B); kwargs...)
+end
 
-_fidelity(A::LPDO{MPO}, B::Choi; kwargs...) = 
-  _fidelity(B, A; kwargs...)
+_fidelity(A::LPDO{MPO}, B::Choi; kwargs...) = _fidelity(B, A; kwargs...)
 
 """
     _fidelity(A::MPO, B::LPDO{MPO}; process::Bool = false, kwargs...)
@@ -176,10 +169,10 @@ _fidelity(A::LPDO{MPO}, B::Choi; kwargs...) =
 If process: fidelity between a unitary MPO and a Choi LPDO
 if not: fidelity between a density  matrix and a LPDO density matrix.
 """
-function _fidelity(A::MPO, B::LPDO{MPO}; process::Bool = false, kwargs...)
+function _fidelity(A::MPO, B::LPDO{MPO}; process::Bool=false, kwargs...)
   A = !process ? A : unitary_mpo_to_choi_mps(A)
   B = !process ? MPO(B) : B
-  return fidelity(A,B; kwargs...)
+  return fidelity(A, B; kwargs...)
 end
 
 """
@@ -187,11 +180,7 @@ end
 
 Quantum fidelity between two LPDO density matrices.
 """
-fidelity(A::LPDO{MPO}, B::LPDO{MPO}; kwargs...) = 
-  fidelity(MPO(A), MPO(B); kwargs...)
-
-
-
+fidelity(A::LPDO{MPO}, B::LPDO{MPO}; kwargs...) = fidelity(MPO(A), MPO(B); kwargs...)
 
 struct ITensorState
   T::ITensor
@@ -203,15 +192,16 @@ end
 
 operator_or_state(A::ITensor) = is_operator(A) ? ITensorOperator(A) : ITensorState(A)
 
-
 """
     fidelity(A::ITensor, B::ITensor)
 
 Compute the quantum fidelity between two ITensors. Wrap each one in the ITensorState
 and the ITensorOperator according to the index structure to allow dispatch.
 """
-function fidelity(A::ITensor, B::ITensor; process::Bool = false, cutoff::Float64 = 1e-15)
-  return fidelity(operator_or_state(A), operator_or_state(B); process = process, cutoff = cutoff)
+function fidelity(A::ITensor, B::ITensor; process::Bool=false, cutoff::Float64=1e-15)
+  return fidelity(
+    operator_or_state(A), operator_or_state(B); process=process, cutoff=cutoff
+  )
 end
 
 """
@@ -235,16 +225,14 @@ function fidelity(A::ITensorState, B::ITensorOperator; kwargs...)
   return real((dag(A.T') * B.T * A.T)[] / K)
 end
 
-fidelity(A::ITensorOperator, B::ITensorState; kwargs...) = 
-  fidelity(B,A)
-
+fidelity(A::ITensorOperator, B::ITensorState; kwargs...) = fidelity(B, A)
 
 """
     fidelity(A::ITensorOperator, B::ITensorOperator; kwargs...)
 
 Fidelity between two operators. Wrap the Choi type as for the TN (above)
 """
-function fidelity(A::ITensorOperator, B::ITensorOperator; kwargs...) 
+function fidelity(A::ITensorOperator, B::ITensorOperator; kwargs...)
   A = ischoi(A.T) ? Choi(A) : A
   B = ischoi(B.T) ? Choi(B) : B
   return _fidelity(A, B; kwargs...)
@@ -256,26 +244,29 @@ end
 
 Fidelity between a Choi and a unitary
 """
-_fidelity(A::Choi, B::ITensorOperator; cutoff::Float64 = 1e-15, kwargs...) = 
-  fidelity(A.X, choitags(B); cutoff = cutoff, kwargs...)
+function _fidelity(A::Choi, B::ITensorOperator; cutoff::Float64=1e-15, kwargs...)
+  return fidelity(A.X, choitags(B); cutoff=cutoff, kwargs...)
+end
 
-_fidelity(A::ITensorOperator, B::Choi; kwargs...) = 
-  _fidelity(B, A; kwargs...)
+_fidelity(A::ITensorOperator, B::Choi; kwargs...) = _fidelity(B, A; kwargs...)
 
 """
     _fidelity(A::Choi{ITensorOperator}, B::Choi{ITensorOperator}; cutoff::Float64 = 1e-15, kwargs...)
 
 fidelity between two Choi matrices
 """
-_fidelity(A::Choi{ITensorOperator}, B::Choi{ITensorOperator}; cutoff::Float64 = 1e-15, kwargs...) = 
-  _fidelity(A.X, B.X; cutoff = cutoff)
+function _fidelity(
+  A::Choi{ITensorOperator}, B::Choi{ITensorOperator}; cutoff::Float64=1e-15, kwargs...
+)
+  return _fidelity(A.X, B.X; cutoff=cutoff)
+end
 
 """
     _fidelity(A::ITensorOperator, B::ITensorOperator; process::Bool = false, kwargs...)
 
 Fidelity betweeb two operators. If process, change the tags and make the unitary into a state (i.e. vectorization).
 """
-function _fidelity(A::ITensorOperator, B::ITensorOperator; process::Bool = false, kwargs...)
+function _fidelity(A::ITensorOperator, B::ITensorOperator; process::Bool=false, kwargs...)
   a = !process ? A : ITensorState(choitags(A).T)
   b = !process ? B : ITensorState(choitags(B).T)
   return __fidelity(a, b; kwargs...)
@@ -286,36 +277,30 @@ end
 
 Fidelity between two density matrices
 """
-function __fidelity(A::ITensorOperator, B::ITensorOperator; cutoff::Float64 = 1e-15)
+function __fidelity(A::ITensorOperator, B::ITensorOperator; cutoff::Float64=1e-15)
   a = copy(A.T)
   b = copy(B.T)
   @assert order(a) == order(b)
   a ./= tr(a)
   b ./= tr(b)
-  sqrt_a = sqrt_hermitian(a; cutoff = cutoff)
+  sqrt_a = sqrt_hermitian(a; cutoff=cutoff)
   F = product(product(sqrt_a, b), sqrt_a)
-  return real(tr(sqrt_hermitian(F; cutoff = cutoff)))^2
+  return real(tr(sqrt_hermitian(F; cutoff=cutoff)))^2
 end
 
 """
 Dummy function
 """
-__fidelity(A::ITensorState, B::ITensorState; kwargs...) =
-  fidelity(A,B)
-
+__fidelity(A::ITensorState, B::ITensorState; kwargs...) = fidelity(A, B)
 
 """
 Finally, the fidelity between TN and ITensors, which simply convert
 the TN into ITensors and call the ITensors fidelities.
 """
 
-fidelity(M::Union{MPS,MPO,LPDO}, T::ITensor; kwargs...) =
-  fidelity(prod(M), T; kwargs...)
+fidelity(M::Union{MPS,MPO,LPDO}, T::ITensor; kwargs...) = fidelity(prod(M), T; kwargs...)
 
-fidelity(T::ITensor, M::Union{MPS,MPO,LPDO}; kwargs...) =
-  fidelity(M, T; kwargs...)
-
-
+fidelity(T::ITensor, M::Union{MPS,MPO,LPDO}; kwargs...) = fidelity(M, T; kwargs...)
 
 """
     frobenius_distance(ρ::Union{MPO, LPDO}, σ::Union{MPO, LPDO})

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -11,7 +11,7 @@ export
   qft,
   ghz,
   dag,
-  
+
   # circuits/trottersuzuki.jl
   trottercircuit,
 
@@ -29,10 +29,10 @@ export
   randombases,
   fullpreparations,
   randompreparations,
-  
+
   # noise.jl
   insertnoise,
-  
+
   # productstates.jl
   qubits,
   qudits,
@@ -50,7 +50,6 @@ export
 
   # lpdo.jl
   LPDO,
-  normalize!,
   logtr,
   tr,
 

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -9,11 +9,11 @@ import ITensors:
   noise,
   dag
 
-import LinearAlgebra: normalize!, tr, norm
+import LinearAlgebra: tr, norm
 
-import SCS
+using SCS: SCS
 
-import Convex
+using Convex: Convex
 
 import Optimisers.state as optimizerstate
 

--- a/src/io.jl
+++ b/src/io.jl
@@ -4,7 +4,6 @@ SAVE AND READ SAMPLES
 
 """
 
-
 """
     writesamples(data::Matrix{Int},
                  [model::Union{MPS, MPO, LPDO, Nothing},]
@@ -94,7 +93,6 @@ function writesamples(data::Matrix{Pair{String,Pair{String,Int}}}, output_path::
   end
 end
 
-
 """
     readsamples(input_path::String)
 
@@ -150,7 +148,6 @@ function readsamples(input_path::String)
   return data
 end
 
-
 """
 Various printing functionalities
 """
@@ -167,8 +164,7 @@ function printmetric(name::String, metric::Complex)
   end
 end
 
-function printobserver(observer::Observer, print_metrics::Union{String,AbstractArray}
-)
+function printobserver(observer::Observer, print_metrics::Union{String,AbstractArray})
   if !isempty(print_metrics)
     if print_metrics isa String
       printmetric(print_metrics, results(observer, print_metrics)[end])
@@ -178,7 +174,5 @@ function printobserver(observer::Observer, print_metrics::Union{String,AbstractA
       end
     end
   end
-  return
+  return nothing
 end
-
-

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -41,11 +41,11 @@ end
 # ITensor
 #
 
-function sqrt_hermitian(ρ::ITensor; cutoff::Float64 = 1e-15)
+function sqrt_hermitian(ρ::ITensor; cutoff::Float64=1e-15)
   if !isapprox(swapprime(dag(ρ), 0 => 1), ρ)
     error("matrix is not hermitian")
   end
-  D, U = eigen(ρ; ishermitian = true, cutoff = cutoff)
+  D, U = eigen(ρ; ishermitian=true, cutoff=cutoff)
   sqrtD = D
   sqrtD .= sqrt.(D)
   return U' * sqrtD * dag(U)

--- a/src/lpdo.jl
+++ b/src/lpdo.jl
@@ -204,6 +204,3 @@ function HDF5.read(
   X = read(g, "X", XT)
   return LPDO(X, ts"Purifier")
 end
-
-
-

--- a/src/optimizers.jl
+++ b/src/optimizers.jl
@@ -1,11 +1,8 @@
-PastaQ.state(optimizer, model::LPDO) = 
-  optimizerstate(optimizer, getparameters(model))
+PastaQ.state(optimizer, model::LPDO) = optimizerstate(optimizer, getparameters(model))
 
-PastaQ.state(optimizer, model::MPS) = 
-  PastaQ.state(optimizer, LPDO(model))
+PastaQ.state(optimizer, model::MPS) = PastaQ.state(optimizer, LPDO(model))
 
-PastaQ.state(optimizer, model::MPO) = 
-  PastaQ.state(optimizer, LPDO(model))
+PastaQ.state(optimizer, model::MPO) = PastaQ.state(optimizer, LPDO(model))
 
 """
     update!(model, grads, optimizer)
@@ -15,15 +12,15 @@ Update a tensor network model
 function PastaQ.update!(model, grads, optimizer)
   L = deepcopy(model)
   opt, st = optimizer
-  θ, ∇ = getparameters(L; ∇ = copy(grads))
+  θ, ∇ = getparameters(L; ∇=copy(grads))
   st, θ′ = Optimisers.update(opt, st, θ, ∇)
-  
+
   setparameters!(L, θ′)
   model.X[:] = L.X
   return model
 end
 
-function getparameters(L::LPDO; ∇ = nothing)
+function getparameters(L::LPDO; ∇=nothing)
   X = L.X
   N = length(X)
   θ = Complex{Float64}[]
@@ -38,17 +35,16 @@ end
 
 function setparameters!(L::LPDO, θ::Vector)
   X = L.X
-  Y = copy(X) 
+  Y = copy(X)
   N = length(X)
-  
+
   cnt = 1
   for j in 1:N
     d = dims(X[j])
     tot_d = prod(d)
-    ϑ = θ[cnt:cnt+tot_d-1]
-    Y[j] = ITensors.itensor(reshape(ϑ, d), inds(X[j])...) 
+    ϑ = θ[cnt:(cnt + tot_d - 1)]
+    Y[j] = ITensors.itensor(reshape(ϑ, d), inds(X[j])...)
     cnt += tot_d
   end
-  X[:] = Y
+  return X[:] = Y
 end
-

--- a/src/productstates.jl
+++ b/src/productstates.jl
@@ -8,15 +8,13 @@
 
 qubits(N::Int) = siteinds("Qubit", N)
 
-qudits(N::Int; dim::Int = 3) = siteinds("Qudit",N; dim = dim)
-
+qudits(N::Int; dim::Int=3) = siteinds("Qudit", N; dim=dim)
 
 #
 # State-like gates, used to define product input states
 #
 
 # TODO: add an arbitrary state specified by angles
-
 
 state(sn::String) = state(StateName(sn))
 state(sn::String, dim::Int) = state(StateName(sn), dim)
@@ -52,7 +50,6 @@ state(::StateName"Z+") = [
   0
 ]
 
-
 state(::StateName"Z-") = [
   0
   1
@@ -65,26 +62,24 @@ state(::StateName"1") = state("Z-")
 
 state(::StateName"T1") = state("Z+")
 state(::StateName"T2") = [
-  1/√3
-  √2/√3
+  1 / √3
+  √2 / √3
 ]
 state(::StateName"T3") = [
-  1/√3
-  √2/√3 * exp(im*2π/3)
+  1 / √3
+  √2 / √3 * exp(im * 2π / 3)
 ]
 state(::StateName"T4") = [
-  1/√3
-  √2/√3 * exp(im*4π/3)
+  1 / √3
+  √2 / √3 * exp(im * 4π / 3)
 ]
-
 
 function state(::StateName{N}, dim::Int) where {N}
   n = parse(Int, String(N))
-  st = zeros(Int64,dim)
+  st = zeros(Int64, dim)
   st[n + 1] = 1
   return st
 end
-
 
 """
     productstate(N::Int)
@@ -95,9 +90,9 @@ end
 Initialize qubits to an MPS wavefunction in the 0 state (`|ψ⟩ = |0⟩ ⊗ |0⟩ ⊗ …`).
 """
 # TODO: add dimension to use qudit instead of qubit
-function productstate(N::Int; dim::Int = 2, sitetype::String = "Qubit")
-  dim > 2 && return productstate(siteinds("Qudit", N; dim = dim))
-  return productstate(siteinds(sitetype,N))
+function productstate(N::Int; dim::Int=2, sitetype::String="Qubit")
+  dim > 2 && return productstate(siteinds("Qudit", N; dim=dim))
+  return productstate(siteinds(sitetype, N))
 end
 
 productstate(sites::Vector{<:Index}) = productMPS(sites, "0")
@@ -120,8 +115,8 @@ productstate(M::Union{MPS,MPO,LPDO}) = productstate(hilbertspace(M))
 Initialize the qubits to a given product state, where the state `T` can be specified either
 with a Vector of states specified as Strings or bit values (0 and 1).
 """
-function productstate(N::Int, states::Vector; dim::Int = 2, sitetype::String = "Qubit")
-  dim > 2 && return productstate(siteinds("Qudit", N; dim = dim), states)
+function productstate(N::Int, states::Vector; dim::Int=2, sitetype::String="Qubit")
+  dim > 2 && return productstate(siteinds("Qudit", N; dim=dim), states)
   return productstate(siteinds(sitetype, N), states)
 end
 
@@ -152,12 +147,11 @@ end
 
 Initialize an MPO that is a product of identity operators.
 """
-function productoperator(N::Int; dim::Int = 2, sitetype::String = "Qubit")
-  dim > 2 && return productoperator(siteinds("Qudit", N; dim = dim))
+function productoperator(N::Int; dim::Int=2, sitetype::String="Qubit")
+  dim > 2 && return productoperator(siteinds("Qudit", N; dim=dim))
   return productoperator(siteinds(sitetype, N))
 end
 
 productoperator(M::Union{MPS,MPO,LPDO}) = productoperator(hilbertspace(M))
 
 productoperator(sites::Vector{<:Index}) = MPO([op("Id", s) for s in sites])
-

--- a/src/randomstates.jl
+++ b/src/randomstates.jl
@@ -373,7 +373,7 @@ function randomprocess(ElT::Type{<:Number}, T::Type, sites::Vector{<:Index}; kwa
       Φ = Φ * √2^length(M)
       M = choi_mps_to_unitary_mpo(Φ)
     else
-      normalize!(M; localnorm = 2)
+      normalize!(M; localnorm=2)
     end
   end
   return M

--- a/src/tomography/fulltomography.jl
+++ b/src/tomography/fulltomography.jl
@@ -5,36 +5,36 @@ Generate a dictionary containing the measurement counts for a set
 of projectors, given a set of single-shot samples with different
 measurement bases (i.e. QST).
 """
-function measurement_counts(samples::Matrix{Pair{String, Int}}; fillzeros::Bool = true)
+function measurement_counts(samples::Matrix{Pair{String,Int}}; fillzeros::Bool=true)
   counts = Dict{Tuple,Dict}()
-  N = size(samples,2)
-  
+  N = size(samples, 2)
+
   if N > 8
     error("Full QST restricted to N ≤ 8")
   end
   # Loop over each measurement in the data
-  for n in 1:size(samples,1)
+  for n in 1:size(samples, 1)
     # Extract the measurement basis and  and outcome
-    basis    = Tuple(first.(samples[n,:]))
-    outcome  = Tuple(last.(samples[n,:]))
-    
+    basis = Tuple(first.(samples[n, :]))
+    outcome = Tuple(last.(samples[n, :]))
+
     # If new basis, add dictionary
-    if !haskey(counts,basis)
+    if !haskey(counts, basis)
       counts[basis] = Dict{Tuple,Int64}()
     end
     # Record outcome
-    if !haskey(counts[basis],outcome)
+    if !haskey(counts[basis], outcome)
       counts[basis][outcome] = 0
     end
     counts[basis][outcome] += 1
   end
-  
+
   if fillzeros
     # Fill the counts with zeros for bitstring never observed
-    for (k1,v1) in counts
-      for index in 0:1<<N-1
-        bitstring = reverse(Tuple(digits.(index,base=2,pad=N)'))
-        if !haskey(counts[k1],bitstring)
+    for (k1, v1) in counts
+      for index in 0:(1 << N - 1)
+        bitstring = reverse(Tuple(digits.(index, base=2, pad=N)'))
+        if !haskey(counts[k1], bitstring)
           counts[k1][bitstring] = 0
         end
       end
@@ -43,8 +43,9 @@ function measurement_counts(samples::Matrix{Pair{String, Int}}; fillzeros::Bool 
   return counts
 end
 
-measurement_counts(samples::Matrix{String}; kwargs...) = 
-  measurement_counts(convertdatapoints(samples); kwargs...)
+function measurement_counts(samples::Matrix{String}; kwargs...)
+  return measurement_counts(convertdatapoints(samples); kwargs...)
+end
 
 """
     measurement_counts(data::Matrix{Pair{String,Pair{String, Int}}}; fillzeros::Bool = true)
@@ -52,8 +53,10 @@ measurement_counts(samples::Matrix{String}; kwargs...) =
 Generate a dictionary containing the measurement counts for a set 
 of input states and measurement projectors (i.e. QPT).
 """
-function measurement_counts(data::Matrix{Pair{String,Pair{String, Int}}}; fillzeros::Bool = true)
-  if size(data,2) > 8
+function measurement_counts(
+  data::Matrix{Pair{String,Pair{String,Int}}}; fillzeros::Bool=true
+)
+  if size(data, 2) > 8
     error("Full QPT restricted to N ≤ 4")
   end
   newdata = []
@@ -61,18 +64,17 @@ function measurement_counts(data::Matrix{Pair{String,Pair{String, Int}}}; fillze
   measurements = last.(data)
   bases = first.(measurements)
   outcomes = last.(measurements)
-  for n in 1:size(bases,1)
-    m = convertdatapoint(outcomes[n,:], bases[n,:])
+  for n in 1:size(bases, 1)
+    m = convertdatapoint(outcomes[n, :], bases[n, :])
     tmp = []
-    for j in 1:size(bases,2)
-      push!(tmp, input_states[n,j])
+    for j in 1:size(bases, 2)
+      push!(tmp, input_states[n, j])
       push!(tmp, m[j])
     end
     push!(newdata, tmp)
   end
-  return measurement_counts(permutedims(hcat(newdata...)); fillzeros = fillzeros) 
+  return measurement_counts(permutedims(hcat(newdata...)); fillzeros=fillzeros)
 end
-
 
 """
     empirical_probabilities(counts::Dict{Tuple,Dict})
@@ -81,14 +83,14 @@ Compute the probabilities from a set of measurement counts.
 """
 function empirical_probabilities(counts::Dict{Tuple,Dict})
   probs = Dict{Tuple,Dict{Tuple,Float64}}(deepcopy(counts))
-  
+
   for basis in keys(probs)
     # Get count dictionary for 2^N projectors in this basis
     counts_in_basis = probs[basis]
-    
+
     # Total number of counts
     tot_counts = sum(values(counts_in_basis))
-    
+
     # Build probabilities
     for projector in keys(counts_in_basis)
       probs[basis][projector] /= tot_counts
@@ -97,8 +99,9 @@ function empirical_probabilities(counts::Dict{Tuple,Dict})
   return probs
 end
 
-empirical_probabilities(samples::Array; fillzeros::Bool=true) = 
-  empirical_probabilities(measurement_counts(samples;fillzeros=fillzeros))
+function empirical_probabilities(samples::Array; fillzeros::Bool=true)
+  return empirical_probabilities(measurement_counts(samples; fillzeros=fillzeros))
+end
 
 """
     projector_matrix(probs::AbstractDict; process::Bool = false, return_probs::Bool = false)
@@ -110,27 +113,27 @@ probability dictionary.
 If `return_probs=true`, return also the 1d vector of probabilities (i.e. the
 1D flattening of the dictionary).
 """
-function design_matrix(probs::AbstractDict; process::Bool = false, return_probs::Bool = false)
+function design_matrix(probs::AbstractDict; process::Bool=false, return_probs::Bool=false)
   A = []
   p̂ = []
-  
-  for (basis,projectors) in probs
-    for (outcome,probability) in projectors
+
+  for (basis, projectors) in probs
+    for (outcome, probability) in projectors
       Π_list = []
       for j in 1:length(outcome)
         if process && isodd(j)
-          Πj = 0.5 * transpose(gate("Id") + (1-2*outcome[j]) * gate(basis[j]))
+          Πj = 0.5 * transpose(gate("Id") + (1 - 2 * outcome[j]) * gate(basis[j]))
         else
-          Πj = 0.5 * (gate("Id") + (1-2*outcome[j]) * gate(basis[j]))
+          Πj = 0.5 * (gate("Id") + (1 - 2 * outcome[j]) * gate(basis[j]))
         end
-        push!(Π_list,Πj)
+        push!(Π_list, Πj)
       end
-      Π = reduce(kron,Π_list)
-      push!(A,conj(vec(Π)))
-      push!(p̂,probability)
+      Π = reduce(kron, Π_list)
+      push!(A, conj(vec(Π)))
+      push!(p̂, probability)
     end
   end
-  
+
   return_probs && return copy(transpose(hcat(A...))), float.(p̂)
   return copy(transpose(hcat(A...)))
 end
@@ -144,24 +147,23 @@ the 2-norm distance between the input density matrix and a positive
 density matrix.
 """
 function make_PSD(ρ::AbstractArray{<:Number,2})
-  μ, μ⃗ = eigen(ρ; sortby=x->-real(x))
+  μ, μ⃗ = eigen(ρ; sortby=x -> -real(x))
   a = 0.0
   μ = real(μ)
   λ = zeros(length(μ))
   i = length(μ)
-  while (μ[i] + a/i < 0.0)
+  while (μ[i] + a / i < 0.0)
     a += μ[i]
     λ[i] = 0.0
     i -= 1
   end
   for j in reverse(1:i)
-    λ[j] = μ[j] + a/i
+    λ[j] = μ[j] + a / i
   end
 
-  ρ_PSD = zeros(ComplexF64,length(μ),length(μ))
+  ρ_PSD = zeros(ComplexF64, length(μ), length(μ))
   for k in 1:length(μ)
-    ρ_PSD += λ[k] * (μ⃗[:,k] * μ⃗[:,k]')
+    ρ_PSD += λ[k] * (μ⃗[:, k] * μ⃗[:, k]')
   end
   return ρ_PSD
 end
-

--- a/src/tomography/quantumtomography.jl
+++ b/src/tomography/quantumtomography.jl
@@ -1,37 +1,40 @@
-function tomography(probabilities::Dict{Tuple,<:Dict}, sites::Vector{<:Index}; 
-                    method::String="linear_inversion", 
-                    fillzeros::Bool=true, 
-                    process::Bool = false,
-                    trρ::Number = 1.0,
-                    max_iters::Int=10000,
-                    kwargs...)
-  
+function tomography(
+  probabilities::Dict{Tuple,<:Dict},
+  sites::Vector{<:Index};
+  method::String="linear_inversion",
+  fillzeros::Bool=true,
+  process::Bool=false,
+  trρ::Number=1.0,
+  max_iters::Int=10000,
+  kwargs...,
+)
+
   # Generate the projector matrix corresponding to the probabilities.
-  A, p = design_matrix(probabilities; return_probs = true, process = process)
-  
-  if (method == "LI"  || method == "linear_inversion")
+  A, p = design_matrix(probabilities; return_probs=true, process=process)
+
+  if (method == "LI" || method == "linear_inversion")
     # Invert the Born rule and reshape
     ρ_vec = pinv(A) * p
-    d = Int(sqrt(size(ρ_vec,1)))
-    ρ̂ = reshape(ρ_vec,(d,d))
-    
+    d = Int(sqrt(size(ρ_vec, 1)))
+    ρ̂ = reshape(ρ_vec, (d, d))
+
     ρ̂ .= ρ̂ * (trρ / tr(ρ̂))
     # Make PSD
     ρ̂ = make_PSD(ρ̂)
   else
-    d = Int(sqrt(size(A,2)))
+    d = Int(sqrt(size(A, 2)))
     N = Int(sqrt(d))
     n = N ÷ 2
-    
+
     # Variational density matrix
-    ρ = Convex.ComplexVariable(d,d)
-    
-    if (method == "LS"  || method == "least_squares") 
+    ρ = Convex.ComplexVariable(d, d)
+
+    if (method == "LS" || method == "least_squares")
       # Minimize the cost function C = ||A ρ⃗ - p̂||²
-      cost_function = Convex.norm(A * vec(ρ) - p) 
+      cost_function = Convex.norm(A * vec(ρ) - p)
     elseif (method == "MLE" || method == "maximum_likelihood")
       # Minimize the negative log likelihood:
-      cost_function = - p' * Convex.log(real(A * vec(ρ)) + 1e-10)
+      cost_function = -p' * Convex.log(real(A * vec(ρ)) + 1e-10)
     else
       error("Tomography method not recognized
        Currently available methods: - LI  : linear inversion
@@ -40,57 +43,90 @@ function tomography(probabilities::Dict{Tuple,<:Dict}, sites::Vector{<:Index};
     end
 
     # Contrained the trace and enforce positivity and hermitianity 
-    if process 
+    if process
       function tracepreserving(ρ)
         for j in 1:n
-          subsystem_dims = [2 for _ in 1:(N+1-j)]
-          ρ = Convex.partialtrace(ρ,j+1,subsystem_dims)
+          subsystem_dims = [2 for _ in 1:(N + 1 - j)]
+          ρ = Convex.partialtrace(ρ, j + 1, subsystem_dims)
         end
         return ρ
       end
-      
-      constraints = [Convex.tr(ρ) == (1<<n) * trρ
-                    Convex.isposdef(ρ)
-                    tracepreserving(ρ) == Matrix{Float64}(I,1<<n,1<<n)
-                    ρ == ρ']
+
+      constraints = [
+        Convex.tr(ρ) == (1 << n) * trρ
+        Convex.isposdef(ρ)
+        tracepreserving(ρ) == Matrix{Float64}(I, 1 << n, 1 << n)
+        ρ == ρ'
+      ]
     else
-      constraints = [Convex.tr(ρ) == trρ 
-                     Convex.isposdef(ρ) 
-                     ρ == ρ']
+      constraints = [
+        Convex.tr(ρ) == trρ
+        Convex.isposdef(ρ)
+        ρ == ρ'
+      ]
     end
     # Use Convex.jl to solve the optimization
-    problem = Convex.minimize(cost_function,constraints)
-    Convex.solve!(problem, () -> SCS.Optimizer(verbose=false,max_iters=max_iters),verbose=false)
+    problem = Convex.minimize(cost_function, constraints)
+    Convex.solve!(
+      problem, () -> SCS.Optimizer(; verbose=false, max_iters=max_iters); verbose=false
+    )
     ρ̂ = ρ.value
   end
   return PastaQ.itensor(ρ̂, sites)
 end
 
-
-tomography(data::Matrix{Pair{String, Int}}; method::String="linear_inversion", fillzeros::Bool=true, kwargs...) = 
-  tomography(empirical_probabilities(data; fillzeros=fillzeros), siteinds("Qubit", size(data,2)); method = method, kwargs...)
-
-tomography(data::Matrix{Pair{String, Int}}, sites::Vector{<:Index}; method::String="linear_inversion", fillzeros::Bool=true, kwargs...) = 
-  tomography(empirical_probabilities(data; fillzeros=fillzeros), sites; method = method, kwargs...)
-
-tomography(data::Matrix{Pair{String,Pair{String, Int}}}; kwargs...) = 
-  tomography(data, siteinds("Qubit", size(data,2)); kwargs...)
-
-function tomography(data::Matrix{Pair{String,Pair{String, Int}}}, sites::Vector{<:Index}; method::String="linear_inversion", fillzeros::Bool=true, kwargs...) 
-  sites_in  = addtags.(sites, "Input")
-  sites_out = addtags.(sites, "Output")
-  process_sites = Index[]
-  for j in 1:size(data,2) 
-    push!(process_sites, sites_in[j]) 
-    push!(process_sites, sites_out[j]) 
-  end
-  tomography(empirical_probabilities(data; fillzeros=fillzeros), process_sites; method = method, process = true, kwargs...)
+function tomography(
+  data::Matrix{Pair{String,Int}};
+  method::String="linear_inversion",
+  fillzeros::Bool=true,
+  kwargs...,
+)
+  return tomography(
+    empirical_probabilities(data; fillzeros=fillzeros),
+    siteinds("Qubit", size(data, 2));
+    method=method,
+    kwargs...,
+  )
 end
 
+function tomography(
+  data::Matrix{Pair{String,Int}},
+  sites::Vector{<:Index};
+  method::String="linear_inversion",
+  fillzeros::Bool=true,
+  kwargs...,
+)
+  return tomography(
+    empirical_probabilities(data; fillzeros=fillzeros), sites; method=method, kwargs...
+  )
+end
 
+function tomography(data::Matrix{Pair{String,Pair{String,Int}}}; kwargs...)
+  return tomography(data, siteinds("Qubit", size(data, 2)); kwargs...)
+end
 
-
-
+function tomography(
+  data::Matrix{Pair{String,Pair{String,Int}}},
+  sites::Vector{<:Index};
+  method::String="linear_inversion",
+  fillzeros::Bool=true,
+  kwargs...,
+)
+  sites_in = addtags.(sites, "Input")
+  sites_out = addtags.(sites, "Output")
+  process_sites = Index[]
+  for j in 1:size(data, 2)
+    push!(process_sites, sites_in[j])
+    push!(process_sites, sites_out[j])
+  end
+  return tomography(
+    empirical_probabilities(data; fillzeros=fillzeros),
+    process_sites;
+    method=method,
+    process=true,
+    kwargs...,
+  )
+end
 
 """
     tomography(train_data::Matrix{Pair{String,Pair{String, Int}}}, L::LPDO;
@@ -114,9 +150,7 @@ The model can be either a unitary circuit (MPO) or a Choi matrix (LPDO).
  - `test_data`: data for computing cross-validation.
  - `outputpath`: if provided, save metrics on file.
 """
-function tomography(
-  train_data::AbstractMatrix, L::LPDO; (observer!)=nothing, kwargs...
-)
+function tomography(train_data::AbstractMatrix, L::LPDO; (observer!)=nothing, kwargs...)
   # Read arguments
   opt = get(kwargs, :optimizer, Optimisers.Descent(0.01))
   batchsize::Int64 = get(kwargs, :batchsize, 100)
@@ -134,27 +168,27 @@ function tomography(
   model = copy(L)
   isqpt = train_data isa Matrix{Pair{String,Pair{String,Int}}}
   localnorm = isqpt ? 2.0 : 1.0
-  
+
   # observer is not passed but earlystop is called
   observer! = (isnothing(observer!) && earlystop) ? Observer() : observer!
-  
+
   # observer is defined
   if !isnothing(observer!)
-    observer!["train_loss"] = nothing 
+    observer!["train_loss"] = nothing
     if !isnothing(test_data)
       observer!["test_loss"] = nothing
     end
     # add the standard early stop function to the observer
     if earlystop
-      stop_if(; loss::Vector) = stopif_loss(; loss = loss, ϵ = 1e-3, min_iter = 10)
+      stop_if(; loss::Vector) = stopif_loss(; loss=loss, ϵ=1e-3, min_iter=10)
       observer!["earlystop"] = stopif
-    end 
+    end
   end
 
   # initialize optimizer
   st = PastaQ.state(opt, model)
   optimizer = (opt, st)
-  
+
   @assert size(train_data, 2) == length(model)
   !isnothing(test_data) && @assert size(test_data)[2] == length(model)
 
@@ -178,10 +212,10 @@ function tomography(
 
         normalized_model = copy(model)
         sqrt_localnorms = []
-        normalize!(normalized_model; 
-                   (sqrt_localnorms!)=sqrt_localnorms, 
-                   localnorm=localnorm)
-        
+        normalize!(
+          normalized_model; (sqrt_localnorms!)=sqrt_localnorms, localnorm=localnorm
+        )
+
         grads, loss = gradients(
           normalized_model,
           batch;
@@ -196,15 +230,13 @@ function tomography(
     end # end @elapsed
     !isnothing(observer!) && push!(last(observer!["train_loss"]), train_loss)
     tot_time += ep_time
-    
+
     # measurement stage
     if ep % observe_step == 0
       normalized_model = copy(model)
       sqrt_localnorms = []
-      normalize!(normalized_model; 
-                 (sqrt_localnorms!)=sqrt_localnorms, 
-                 localnorm=localnorm)
-      
+      normalize!(normalized_model; (sqrt_localnorms!)=sqrt_localnorms, localnorm=localnorm)
+
       if !isnothing(test_data)
         test_loss = nll(normalized_model, test_data)
         !isnothing(observer!) && push!(last(observer!["test_loss"]), test_loss)
@@ -218,21 +250,31 @@ function tomography(
 
       # update observer
       if !isnothing(observer!)
-        loss = (!isnothing(test_data) ? results(observer!, "test_loss") : 
-                                        results(observer!, "train_loss"))
-        
-        model_to_observe = (isqpt && (normalized_model isa LPDO{MPS}) ? choi_mps_to_unitary_mpo(normalized_model) : 
-                                  !isqpt && (normalized_model isa LPDO{MPS}) ? normalized_model.X :
-                                                                               normalized_model)
-        update!(observer!, model_to_observe; train_loss = train_loss,
-                                             test_loss  = test_loss)
+        loss = (
+          if !isnothing(test_data)
+            results(observer!, "test_loss")
+          else
+            results(observer!, "train_loss")
+          end
+        )
+
+        model_to_observe = (
+          if isqpt && (normalized_model isa LPDO{MPS})
+            choi_mps_to_unitary_mpo(normalized_model)
+          elseif !isqpt && (normalized_model isa LPDO{MPS})
+            normalized_model.X
+          else
+            normalized_model
+          end
+        )
+        update!(observer!, model_to_observe; train_loss=train_loss, test_loss=test_loss)
       end
 
       # printing
-      if outputlevel ≥ 1 
+      if outputlevel ≥ 1
         @printf("%-4d  ", ep)
         @printf("⟨logP⟩ = %-4.4f  ", train_loss)
-        if !isnothing(test_data) 
+        if !isnothing(test_data)
           @printf("(%.4f)  ", test_loss)
         end
         # TODO: add the trace preserving cost function here for QPT
@@ -246,7 +288,8 @@ function tomography(
         save(observerpath, observer!)
         if savestate
           if isqpt
-            model_to_be_saved = model isa LPDO{MPS} ? choi_mps_to_unitary_mpo(best_model) : best_model
+            model_to_be_saved =
+              model isa LPDO{MPS} ? choi_mps_to_unitary_mpo(best_model) : best_model
           else
             model_to_be_saved = model isa LPDO{MPS} ? best_model.X : best_model
           end
@@ -257,27 +300,35 @@ function tomography(
         end
       end
     end
-    !isnothing(observer!) && haskey(observer!.data,"earlystop") && results(observer!, "earlystop")[end] && break
+    !isnothing(observer!) &&
+      haskey(observer!.data, "earlystop") &&
+      results(observer!, "earlystop")[end] &&
+      break
   end
   return best_model
 end
 
 # QST
-tomography(data::Matrix{Pair{String,Int}}, ψ::MPS; kwargs...) = 
-  tomography(data, LPDO(ψ); kwargs...).X
+function tomography(data::Matrix{Pair{String,Int}}, ψ::MPS; kwargs...)
+  return tomography(data, LPDO(ψ); kwargs...).X
+end
 
-tomography(train_data::Vector{<:Vector{Pair{String,Int}}}, args...; kwargs...) = 
-  tomography(permutedims(hcat(train_data...)), args...; kwargs...)
-
+function tomography(train_data::Vector{<:Vector{Pair{String,Int}}}, args...; kwargs...)
+  return tomography(permutedims(hcat(train_data...)), args...; kwargs...)
+end
 
 # QPT
-tomography(data::Matrix{Pair{String,Pair{String,Int}}}, U::MPO; kwargs...) = 
-  choi_mps_to_unitary_mpo(tomography(data, LPDO(unitary_mpo_to_choi_mps(U)); kwargs...))
+function tomography(data::Matrix{Pair{String,Pair{String,Int}}}, U::MPO; kwargs...)
+  return choi_mps_to_unitary_mpo(
+    tomography(data, LPDO(unitary_mpo_to_choi_mps(U)); kwargs...)
+  )
+end
 
-tomography(train_data::Vector{<:Vector{Pair{String,Pair{String,Int}}}}, args...; kwargs...) = 
-  tomography(permutedims(hcat(train_data...)), args...; kwargs...)
-
-
+function tomography(
+  train_data::Vector{<:Vector{Pair{String,Pair{String,Int}}}}, args...; kwargs...
+)
+  return tomography(permutedims(hcat(train_data...)), args...; kwargs...)
+end
 
 """
 EARLY STOPPING FUNCTIONS
@@ -287,8 +338,8 @@ EARLY STOPPING FUNCTIONS
 #  fidelity(M1,M2) ≤ ϵ
 
 function stopif_loss(; loss::Vector, ϵ::Number, min_iter::Number)
-  length(loss) < min_iter+1 && return false
-  avgloss = StatsBase.mean(loss[end-size:end])
-  Δ = StatsBase.sem(historyloss[end-size:end])
-  return Δ/avgloss < ϵ
+  length(loss) < min_iter + 1 && return false
+  avgloss = StatsBase.mean(loss[(end - size):end])
+  Δ = StatsBase.sem(historyloss[(end - size):end])
+  return Δ / avgloss < ϵ
 end

--- a/src/tomography/tensornetwork-processtomography.jl
+++ b/src/tomography/tensornetwork-processtomography.jl
@@ -538,7 +538,7 @@ function gradients(
   data::Matrix{Pair{String,Pair{String,Int}}};
   sqrt_localnorms=nothing,
   trace_preserving_regularizer=nothing,
-  kwargs...
+  kwargs...,
 )
   g_logZ, logZ = gradlogZ(L; sqrt_localnorms=sqrt_localnorms)
   g_nll, NLL = gradnll(L, data; sqrt_localnorms=sqrt_localnorms)
@@ -551,13 +551,12 @@ function gradients(
   if !isnothing(trace_preserving_regularizer)
     grads += trace_preserving_regularizer * g_TP
   end
-  
+
   # TODO: check if this slows down the training
   # permute the gradients
   for j in 1:length(L)
     grads[j] = permute(grads[j], inds(L.X[j])...)
   end
-  
+
   return grads, loss
 end
-

--- a/src/tomography/tensornetwork-statetomography.jl
+++ b/src/tomography/tensornetwork-statetomography.jl
@@ -403,13 +403,15 @@ end
 Compute the gradients of the cost function:
 `C = log(Z) - ⟨log P(σ)⟩_data`
 """
-function gradients(L::LPDO, data::Matrix{Pair{String,Int}}; sqrt_localnorms=nothing, kwargs...)
+function gradients(
+  L::LPDO, data::Matrix{Pair{String,Int}}; sqrt_localnorms=nothing, kwargs...
+)
   g_logZ, logZ = gradlogZ(L; sqrt_localnorms=sqrt_localnorms)
   g_nll, nll = gradnll(L, data; sqrt_localnorms=sqrt_localnorms)
 
   grads = g_logZ + g_nll
   loss = logZ + nll
-  
+
   # TODO: check if this slows down the training
   # permute the gradients
   for j in 1:length(L)
@@ -419,6 +421,6 @@ function gradients(L::LPDO, data::Matrix{Pair{String,Int}}; sqrt_localnorms=noth
   return grads, loss
 end
 
-gradients(ψ::MPS, data::Matrix{Pair{String,Int}}; localnorms=nothing) = 
-  gradients(LPDO(ψ), data; sqrt_localnorms=localnorms)
-
+function gradients(ψ::MPS, data::Matrix{Pair{String,Int}}; localnorms=nothing)
+  return gradients(LPDO(ψ), data; sqrt_localnorms=localnorms)
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,8 +1,8 @@
 # TODO: turn this into an ITensors.jl function `originalsiteinds`
 # that generically returns the site indices that would be used to
 # make an object of the same type with the same indices.
-hilbertspace(M::MPS)  = siteinds(first, M; plev=0)
-hilbertspace(M::MPO)  = dag.(siteinds(first, M; plev=0))
+hilbertspace(M::MPS) = siteinds(first, M; plev=0)
+hilbertspace(M::MPO) = dag.(siteinds(first, M; plev=0))
 hilbertspace(L::LPDO) = dag.(siteinds(first, L.X; plev=0, tags=!purifier_tags(L)))
 
 """
@@ -142,7 +142,7 @@ function ischoi(M::LPDO{MPO})
   return true
 end
 
-function ischoi(M::MPO) 
+function ischoi(M::MPO)
   !haschoitags(M) && return false
   for j in 1:length(M)
     length(inds(M[j], "Site")) != 4 && return false
@@ -151,7 +151,6 @@ function ischoi(M::MPO)
 end
 
 ischoi(M::ITensor) = haschoitags(M)
-
 
 """
     haschoitags(L::LPDO)
@@ -175,7 +174,7 @@ end
 function haschoitags(M::ITensor)
   N = nsites(M)
   for j in 1:N
-    !(hastags(M,"Input,n=$j") && hastags(M,"Output,n=$j")) && return false
+    !(hastags(M, "Input,n=$j") && hastags(M, "Output,n=$j")) && return false
   end
   return true
 end
@@ -206,8 +205,7 @@ function choitags(T::ITensor)
   return noprime(T)
 end
 
-choitags(O::ITensorOperator) = 
-  ITensorState(choitags(O.T))
+choitags(O::ITensorOperator) = ITensorState(choitags(O.T))
 
 """
     mpotags(U::MPO)
@@ -237,9 +235,8 @@ mpotags(M::Union{MPS,MPO}) = mpotags(LPDO(M)).X
 Transforms a unitary MPO into a Choi MPS with appropriate tags.
 """
 unitary_mpo_to_choi_mps(U::MPO) = convert(MPS, choitags(U))
-unitary_mpo_to_choi_mps(T::ITensor) = choitags(T) 
+unitary_mpo_to_choi_mps(T::ITensor) = choitags(T)
 unitary_mpo_to_choi_mps(L::LPDO{MPO}) = unitary_mpo_to_choi_mps(L.X)
-
 
 """
     unitary_mpo_to_choi_mpo(U::MPO)
@@ -265,20 +262,17 @@ Inverse of `unitary_mpo_to_choi_mps`.
 choi_mps_to_unitary_mpo(Ψ::MPS) = mpotags(convert(MPO, Ψ))
 choi_mps_to_unitary_mpo(L::LPDO{MPS}) = choi_mps_to_unitary_mpo(L.X)
 
-
 function nsites(T::ITensor)
-  s1 = inds(T,tags="Site,n=1")
+  s1 = inds(T; tags="Site,n=1")
   # Wavefunction
   if length(s1) == 1 || length(s1) == 2
-    return length(inds(T,plev=0))
-  # Choi matrix
+    return length(inds(T; plev=0))
+    # Choi matrix
   elseif length(s1) == 4
-    return length(inds(T,plev=0)) ÷ 2
+    return length(inds(T; plev=0)) ÷ 2
   else
     error("Indices not recognized")
   end
 end
 
-nsites(M::Union{MPS,MPO,LPDO}) = 
-  length(M)
-
+nsites(M::Union{MPS,MPO,LPDO}) = length(M)

--- a/test/array.jl
+++ b/test/array.jl
@@ -3,7 +3,6 @@ using ITensors
 using Test
 using LinearAlgebra
 
-
 @testset "array" begin
   N = 5
   ψ = productstate(N)
@@ -27,137 +26,138 @@ using LinearAlgebra
 end
 
 @testset "array for MPS/MPO" begin
-  
   N = 5
   depth = 3
-  circuit = randomcircuit(N; depth = depth)
+  circuit = randomcircuit(N; depth=depth)
   qubits = siteinds("Qubit", N)
-  
+
   # MPS wavefunction
   ψ = runcircuit(qubits, circuit)
   ψvec = PastaQ.array(ψ)
 
-  basis = vec(reverse.(Iterators.product(fill([0,1],N)...)))
-  
-  for (k,s) in enumerate(basis)
+  basis = vec(reverse.(Iterators.product(fill([0, 1], N)...)))
+
+  for (k, s) in enumerate(basis)
     σ = productstate(qubits, [s...])
-    ψσ = inner(σ,ψ)
+    ψσ = inner(σ, ψ)
     @test ψσ ≈ ψvec[k]
   end
-  
+
   # MPO unitary
-  U = runcircuit(qubits, circuit; process = true)
+  U = runcircuit(qubits, circuit; process=true)
   Umat = PastaQ.array(U)
 
-  basis = vec(reverse.(Iterators.product(fill([0,1],N)...)))
-  
-  for (k,s) in enumerate(basis)
+  basis = vec(reverse.(Iterators.product(fill([0, 1], N)...)))
+
+  for (k, s) in enumerate(basis)
     σ = productstate(qubits, [s...])
-    for (kp,sp) in enumerate(basis)
+    for (kp, sp) in enumerate(basis)
       σp = productstate(qubits, [sp...])
       Uσσp = inner(σ, U, σp)
-      @test Uσσp ≈ Umat[k,kp]
+      @test Uσσp ≈ Umat[k, kp]
     end
   end
-  
+
   # MPO density matrix 
-  ρ = runcircuit(qubits, circuit; noise = ("DEP",(p=0.01,)))
+  ρ = runcircuit(qubits, circuit; noise=("DEP", (p=0.01,)))
   ρmat = PastaQ.array(ρ)
 
-  basis = vec(reverse.(Iterators.product(fill([0,1],N)...)))
-  
-  for (k,s) in enumerate(basis)
+  basis = vec(reverse.(Iterators.product(fill([0, 1], N)...)))
+
+  for (k, s) in enumerate(basis)
     σ = productstate(qubits, [s...])
-    for (kp,sp) in enumerate(basis)
+    for (kp, sp) in enumerate(basis)
       σp = productstate(qubits, [sp...])
       ρσσp = inner(σ, ρ, σp)
-      @test ρσσp ≈ ρmat[k,kp]
+      @test ρσσp ≈ ρmat[k, kp]
     end
   end
-  
+
   # LPDO density matrix
-  ρ = normalize!(randomstate(qubits; χ = 4, ξ = 2))
+  ρ = PastaQ.normalize!(randomstate(qubits; χ=4, ξ=2))
   ρmat = PastaQ.array(ρ)
-  
+
   ρmpo = MPO(ρ)
-  basis = vec(reverse.(Iterators.product(fill([0,1],N)...)))
-  
-  for (k,s) in enumerate(basis)
+  basis = vec(reverse.(Iterators.product(fill([0, 1], N)...)))
+
+  for (k, s) in enumerate(basis)
     σ = productstate(qubits, [s...])
-    for (kp,sp) in enumerate(basis)
+    for (kp, sp) in enumerate(basis)
       σp = productstate(qubits, [sp...])
       ρσσp = inner(σ, ρmpo, σp)
-      @test ρσσp ≈ ρmat[k,kp]
+      @test ρσσp ≈ ρmat[k, kp]
     end
   end
-  
-
 
   # MPO Choi matrix 
   N = 3
   depth = 3
-  circuit = randomcircuit(N; depth = depth)
+  circuit = randomcircuit(N; depth=depth)
   qubits = siteinds("Qubit", N)
-  
-  Λ = runcircuit(qubits, circuit; process = true, noise = ("DEP",(p=0.01,)))
+
+  Λ = runcircuit(qubits, circuit; process=true, noise=("DEP", (p=0.01,)))
   Λmat = PastaQ.array(Λ)
 
-  basis = vec(reverse.(Iterators.product(fill([0,1], 2*N)...)))
-  qubits_in  = [firstind(Λ[j], tags = "Input", plev = 0) for j in 1:N] 
-  qubits_out = [firstind(Λ[j], tags = "Output", plev = 0) for j in 1:N] 
-  
-  for (k,s) in enumerate(basis)
-    s_in  = s[1:2:end]
+  basis = vec(reverse.(Iterators.product(fill([0, 1], 2 * N)...)))
+  qubits_in = [firstind(Λ[j]; tags="Input", plev=0) for j in 1:N]
+  qubits_out = [firstind(Λ[j]; tags="Output", plev=0) for j in 1:N]
+
+  for (k, s) in enumerate(basis)
+    s_in = s[1:2:end]
     s_out = s[2:2:end]
-    for (kp,sp) in enumerate(basis)
-      sp_in  = sp[1:2:end]
+    for (kp, sp) in enumerate(basis)
+      sp_in = sp[1:2:end]
       sp_out = sp[2:2:end]
       Λc = copy(Λ)
       for j in 1:N
-        Λc[j] = Λc[j] * prime(state(qubits_in[j],s_in[j]+1)) * state(qubits_in[j], sp_in[j]+1) 
+        Λc[j] =
+          Λc[j] *
+          prime(state(qubits_in[j], s_in[j] + 1)) *
+          state(qubits_in[j], sp_in[j] + 1)
       end
-      σ  = productstate(qubits_out, [s_out...])
+      σ = productstate(qubits_out, [s_out...])
       σp = productstate(qubits_out, [sp_out...])
       Λel = inner(σ, Λc, σp)
-      @test Λel ≈ Λmat[k,kp]
-    end   
+      @test Λel ≈ Λmat[k, kp]
+    end
   end
-  
+
   # LPDO Choi matrix
-  
-  Λ = normalize!(randomprocess(qubits; χ = 4, ξ = 2); localnorm = 2)
+
+  Λ = PastaQ.normalize!(randomprocess(qubits; χ=4, ξ=2); localnorm=2)
   Λmat = PastaQ.array(Λ)
 
   Λmpo = MPO(Λ)
-  qubits_in  = [firstind(Λ.X[j], tags = "Input", plev = 0) for j in 1:N] 
-  qubits_out = [firstind(Λ.X[j], tags = "Output", plev = 0) for j in 1:N] 
-  
-  for (k,s) in enumerate(basis)
-    s_in  = s[1:2:end]
+  qubits_in = [firstind(Λ.X[j]; tags="Input", plev=0) for j in 1:N]
+  qubits_out = [firstind(Λ.X[j]; tags="Output", plev=0) for j in 1:N]
+
+  for (k, s) in enumerate(basis)
+    s_in = s[1:2:end]
     s_out = s[2:2:end]
-    for (kp,sp) in enumerate(basis)
-      sp_in  = sp[1:2:end]
+    for (kp, sp) in enumerate(basis)
+      sp_in = sp[1:2:end]
       sp_out = sp[2:2:end]
       Λc = copy(Λmpo)
       for j in 1:N
-        Λc[j] = Λc[j] * prime(state(qubits_in[j],s_in[j]+1)) * state(qubits_in[j], sp_in[j]+1) 
+        Λc[j] =
+          Λc[j] *
+          prime(state(qubits_in[j], s_in[j] + 1)) *
+          state(qubits_in[j], sp_in[j] + 1)
       end
-      σ  = productstate(qubits_out, [s_out...])
+      σ = productstate(qubits_out, [s_out...])
       σp = productstate(qubits_out, [sp_out...])
       Λel = inner(σ, Λc, σp)
-      @test Λel ≈ Λmat[k,kp]
-    end   
+      @test Λel ≈ Λmat[k, kp]
+    end
   end
 end
 
-
 @testset "array for full representation" begin
-  
   N = 5
   depth = 3
-  circuit = randomcircuit(N; depth = depth)
+  circuit = randomcircuit(N; depth=depth)
   qubits = siteinds("Qubit", N)
-  
+
   # MPS wavefunction
   ψ = runcircuit(qubits, circuit)
   ψvec = PastaQ.array(ψ)
@@ -166,22 +166,21 @@ end
   @test ψvec ≈ ψtest
 
   # MPO unitary
-  U = runcircuit(qubits, circuit; process = true)
+  U = runcircuit(qubits, circuit; process=true)
   Umat = PastaQ.array(U)
   Uprod = prod(U)
   Utest = PastaQ.array(Uprod)
   @test Umat ≈ Utest
 
-
   # MPO density matrix 
-  ρ = runcircuit(qubits, circuit; noise = ("DEP",(p=0.01,)))
+  ρ = runcircuit(qubits, circuit; noise=("DEP", (p=0.01,)))
   ρmat = PastaQ.array(ρ)
   ρprod = prod(ρ)
   ρtest = PastaQ.array(ρprod)
   @test ρtest ≈ ρmat
 
   # LPDO density matrix
-  ρ = normalize!(randomstate(qubits; χ = 4, ξ = 2))
+  ρ = PastaQ.normalize!(randomstate(qubits; χ=4, ξ=2))
   ρmat = PastaQ.array(ρ)
   ρprod = prod(ρ)
   ρtest = PastaQ.array(ρprod)
@@ -190,38 +189,36 @@ end
   # MPO Choi matrix 
   N = 3
   depth = 3
-  circuit = randomcircuit(N; depth = depth)
+  circuit = randomcircuit(N; depth=depth)
   qubits = siteinds("Qubit", N)
-  
-  Λ = runcircuit(qubits, circuit; process = true, noise = ("DEP",(p=0.01,)))
+
+  Λ = runcircuit(qubits, circuit; process=true, noise=("DEP", (p=0.01,)))
   Λmat = PastaQ.array(Λ)
   Λprod = prod(Λ)
   Λtest = PastaQ.array(Λprod)
   @test Λmat ≈ Λtest
-  
+
   # LPDO Choi matrix
-  Λ = normalize!(randomprocess(qubits; χ = 4, ξ = 2); localnorm = 2)
+  Λ = PastaQ.normalize!(randomprocess(qubits; χ=4, ξ=2); localnorm=2)
   Λmat = PastaQ.array(Λ)
   Λprod = prod(Λ)
   Λtest = PastaQ.array(Λprod)
   @test Λmat ≈ Λtest
 end
 
-
 @testset "dense states to itensors" begin
   N = 2
-  d = 1<<N
-  gates = randomcircuit(N; depth = 4)
-  ψ = runcircuit(N,gates)
-  
+  d = 1 << N
+  gates = randomcircuit(N; depth=4)
+  ψ = runcircuit(N, gates)
+
   sites = siteinds("Qubit", N)
   ψvec = PastaQ.array(ψ)
   ϕ = PastaQ.itensor(ψvec, sites)
   @test PastaQ.array(ϕ) ≈ ψvec
 
-  ρ = runcircuit(N, gates; noise = ("DEP",(p=0.1,)))
-  ρmat = PastaQ.array(ρ) 
+  ρ = runcircuit(N, gates; noise=("DEP", (p=0.1,)))
+  ρmat = PastaQ.array(ρ)
   ϱ = PastaQ.itensor(ρmat, sites)
   @test PastaQ.array(ϱ) ≈ ρmat
-
 end

--- a/test/circuits.jl
+++ b/test/circuits.jl
@@ -10,12 +10,14 @@ using Random
   for i in 1:1000
     depth = 4
     N = rand(3:50)
-    gates = randomcircuit(N; depth = depth, twoqubitgates="CX", onequbitgates="Rn")
+    gates = randomcircuit(N; depth=depth, twoqubitgates="CX", onequbitgates="Rn")
     n = nqubits(gates)
     @test N == n
     @test PastaQ.nlayers(gates) == depth
     @test PastaQ.ngates(gates) == depth ÷ 2 * (2 * N ÷ 2 - 1 + 2 * N)
-    gates = randomcircuit(N; depth = depth, twoqubitgates="CX", onequbitgates="Rn", layered=false)
+    gates = randomcircuit(
+      N; depth=depth, twoqubitgates="CX", onequbitgates="Rn", layered=false
+    )
     n = nqubits(gates)
     @test N == n
     @test PastaQ.nlayers(gates) == 1
@@ -23,22 +25,22 @@ using Random
   end
 
   N = 3
-  
+
   # MPS
-  circuit = randomcircuit(N; depth = 4)
-  ψ = runcircuit(circuit; full_representation = true) 
+  circuit = randomcircuit(N; depth=4)
+  ψ = runcircuit(circuit; full_representation=true)
   @test PastaQ.nsites(ψ) == N
   # MPO
-  U = runcircuit(circuit; full_representation = true, process = true) 
+  U = runcircuit(circuit; full_representation=true, process=true)
   @test PastaQ.nsites(U) == N
   # LPDO DM
-  ρ = prod(randomstate(N; ξ = 2)) 
+  ρ = prod(randomstate(N; ξ=2))
   @test PastaQ.nsites(ρ) == N
-  
+
   # MPO Choi
-  Λ = runcircuit(circuit; noise = ("DEP",(p=0.01,)), full_representation = true, process = true) 
+  Λ = runcircuit(circuit; noise=("DEP", (p=0.01,)), full_representation=true, process=true)
   @test PastaQ.nsites(Λ) == N
-  Λ = prod(randomprocess(N; ξ = 2)) 
+  Λ = prod(randomprocess(N; ξ=2))
   @test PastaQ.nsites(Λ) == N
 end
 
@@ -84,13 +86,13 @@ end
   pars = PastaQ.randomparams("Rz")
   @test haskey(pars, :ϕ)
   pars = PastaQ.randomparams("Rn")
-  @test haskey(pars,:θ)
-  @test haskey(pars,:ϕ)
-  @test haskey(pars,:λ)
-  
-  pars = PastaQ.randomparams("RandomUnitary",2)
-  @test haskey(pars,:random_matrix)
-  @test size(pars[:random_matrix]) == (4,4)
+  @test haskey(pars, :θ)
+  @test haskey(pars, :ϕ)
+  @test haskey(pars, :λ)
+
+  pars = PastaQ.randomparams("RandomUnitary", 2)
+  @test haskey(pars, :random_matrix)
+  @test size(pars[:random_matrix]) == (4, 4)
   @test pars[:random_matrix] isa Matrix{ComplexF64}
 end
 
@@ -112,56 +114,64 @@ end
 @testset "random circuits" begin
   N = 30
   depth = 10
-  circuit = randomcircuit(N; depth = depth, twoqubitgates="RandomUnitary")
+  circuit = randomcircuit(N; depth=depth, twoqubitgates="RandomUnitary")
   @test length(circuit) == depth
   for d in 1:depth
     @test all(x -> x == "RandomUnitary", first.(circuit[depth]))
   end
 
-  circuit = randomcircuit(N;depth = depth, twoqubitgates="CX")
+  circuit = randomcircuit(N; depth=depth, twoqubitgates="CX")
   @test PastaQ.nlayers(circuit) == depth
   for d in 1:depth
     @test all(x -> x == "CX", first.(circuit[depth]))
   end
 
-  circuit = randomcircuit(N; depth = depth, twoqubitgates="CX", onequbitgates="Rn")
+  circuit = randomcircuit(N; depth=depth, twoqubitgates="CX", onequbitgates="Rn")
   @test size(circuit, 1) == depth
 
-  circuit = randomcircuit(N; depth = depth, twoqubitgates="RandomUnitary", onequbitgates=["Rn", "X"]
+  circuit = randomcircuit(
+    N; depth=depth, twoqubitgates="RandomUnitary", onequbitgates=["Rn", "X"]
   )
   @test size(circuit, 1) == depth
 
   Lx = 5
   Ly = 5
-  circuit = randomcircuit((Lx,Ly); depth = depth, twoqubitgates="RandomUnitary", onequbitgates=["Rn", "X"])
-  @test nqubits(circuit) == Lx*Ly
-  
+  circuit = randomcircuit(
+    (Lx, Ly); depth=depth, twoqubitgates="RandomUnitary", onequbitgates=["Rn", "X"]
+  )
+  @test nqubits(circuit) == Lx * Ly
+
   Lx = 5
   Ly = 5
-  circuit = randomcircuit((Lx,Ly); depth = depth,  twoqubitgates="RandomUnitary", onequbitgates=["Rn", "X"], rotated = true)
-  @test nqubits(circuit) == Lx*Ly
+  circuit = randomcircuit(
+    (Lx, Ly);
+    depth=depth,
+    twoqubitgates="RandomUnitary",
+    onequbitgates=["Rn", "X"],
+    rotated=true,
+  )
+  @test nqubits(circuit) == Lx * Ly
 end
 
 @testset "dag circuit" begin
-
   N = 2
   depth = 4
 
-  circuit = randomcircuit(N; depth = depth, twoqubitgates = "CX", onequbitgates = "Rn")
-  U = PastaQ.array(runcircuit(circuit; process = true))
+  circuit = randomcircuit(N; depth=depth, twoqubitgates="CX", onequbitgates="Rn")
+  U = PastaQ.array(runcircuit(circuit; process=true))
   dagcircuit = dag(circuit)
-  V = PastaQ.array(runcircuit(dagcircuit; process = true))
+  V = PastaQ.array(runcircuit(dagcircuit; process=true))
   @test U ≈ V'
-  
-  circuit = randomcircuit(N; depth = depth, twoqubitgates = "RandomUnitary", onequbitgates = "Rn", layered = false)
-  U = PastaQ.array(runcircuit(circuit; process = true))
+
+  circuit = randomcircuit(
+    N; depth=depth, twoqubitgates="RandomUnitary", onequbitgates="Rn", layered=false
+  )
+  U = PastaQ.array(runcircuit(circuit; process=true))
   dagcircuit = dag(circuit)
-  V = PastaQ.array(runcircuit(dagcircuit; process = true))
+  V = PastaQ.array(runcircuit(dagcircuit; process=true))
   @test U ≈ V'
-  
+
   dagdagcircuit = dag(dagcircuit)
-  Up = PastaQ.array(runcircuit(dagdagcircuit; process = true))
+  Up = PastaQ.array(runcircuit(dagdagcircuit; process=true))
   @test U ≈ Up
-
 end
-

--- a/test/deprecated.jl
+++ b/test/deprecated.jl
@@ -8,22 +8,22 @@ using Test
   sites = siteinds("Qubit", N)
 
   q = qubits(N)
-  @test q isa MPS 
+  @test q isa MPS
   @test length(q) == N
 
   q = qubits(sites)
-  @test q isa MPS 
+  @test q isa MPS
   @test length(q) == N
-  @test q ≈ productstate(sites) 
-  
+  @test q ≈ productstate(sites)
+
   ψ = randomstate(sites)
   q = qubits(ψ)
-  @test q isa MPS 
+  @test q isa MPS
   @test length(q) == N
   @test siteinds(ψ) == siteinds(q)
 
-  q = qubits(sites, ["Z+","Z-","X+","Y-","X+"])
-  @test q isa MPS 
+  q = qubits(sites, ["Z+", "Z-", "X+", "Y-", "X+"])
+  @test q isa MPS
   @test length(q) == N
-  @test q ≈ productstate(sites, ["Z+","Z-","X+","Y-","X+"])
+  @test q ≈ productstate(sites, ["Z+", "Z-", "X+", "Y-", "X+"])
 end

--- a/test/distances.jl
+++ b/test/distances.jl
@@ -6,9 +6,9 @@ using Random
 
 @testset "quantum state fidelity: normalized input states" begin
   N = 4
-  circuit1 = randomcircuit(N; depth = 3)
-  circuit2 = randomcircuit(N; depth = 3)
-  
+  circuit1 = randomcircuit(N; depth=3)
+  circuit2 = randomcircuit(N; depth=3)
+
   sites = siteinds("Qubit", N)
   # MPS wavefunction
   ψ1 = runcircuit(sites, circuit1)
@@ -17,8 +17,8 @@ using Random
   ρ1 = runcircuit(sites, circuit1; noise=("DEP", (p=0.01,)))
   ρ2 = runcircuit(sites, circuit2; noise=("DEP", (p=0.01,)))
   # LPDO density matrix
-  ϱ1 = normalize!(randomstate(sites; χ = 2, ξ = 3))
-  ϱ2 = normalize!(randomstate(sites; χ = 2, ξ = 3))
+  ϱ1 = PastaQ.normalize!(randomstate(sites; χ=2, ξ=3))
+  ϱ2 = PastaQ.normalize!(randomstate(sites; χ=2, ξ=3))
 
   ψ1vec = PastaQ.array(ψ1)
   ρ1mat = PastaQ.array(ρ1)
@@ -45,54 +45,52 @@ using Random
   ϱ1prod = prod(ϱ1)
   ϱ2prod = prod(ϱ2)
 
-  @test fidelity(ψ1prod, ψ2prod) ≈ fidelity(ψ1, ψ2)  
+  @test fidelity(ψ1prod, ψ2prod) ≈ fidelity(ψ1, ψ2)
   @test fidelity(ψ1prod, ψ2) ≈ fidelity(ψ1, ψ2)
   @test fidelity(ψ1, ψ2prod) ≈ fidelity(ψ1, ψ2)
 
-  @test fidelity(ψ1prod, ρ2prod) ≈ fidelity(ψ1, ρ2) 
-  @test fidelity(ψ1prod, ρ2) ≈ fidelity(ψ1, ρ2) 
-  @test fidelity(ψ1, ρ2prod) ≈ fidelity(ψ1, ρ2) 
-  
-  @test fidelity(ψ1prod, ϱ2prod) ≈ fidelity(ψ1, ϱ2) 
-  @test fidelity(ψ1prod, ϱ2) ≈ fidelity(ψ1, ϱ2) 
-  @test fidelity(ψ1, ϱ2prod) ≈ fidelity(ψ1, ϱ2) 
-                                           
-  @test fidelity(ρ1prod, ρ2prod) ≈ fidelity(ρ1, ρ2) 
-  @test fidelity(ρ1, ρ2prod) ≈ fidelity(ρ1, ρ2) 
-  @test fidelity(ρ1prod, ρ2) ≈ fidelity(ρ1, ρ2) 
-  
-  @test fidelity(ρ1prod, ϱ2prod) ≈ fidelity(ρ1, ϱ2) 
-  @test fidelity(ρ1, ϱ2prod) ≈ fidelity(ρ1, ϱ2) 
-  @test fidelity(ρ1prod, ϱ2) ≈ fidelity(ρ1, ϱ2) 
+  @test fidelity(ψ1prod, ρ2prod) ≈ fidelity(ψ1, ρ2)
+  @test fidelity(ψ1prod, ρ2) ≈ fidelity(ψ1, ρ2)
+  @test fidelity(ψ1, ρ2prod) ≈ fidelity(ψ1, ρ2)
 
-  @test fidelity(ϱ1prod, ϱ2prod) ≈ fidelity(ϱ1, ϱ2) 
-  @test fidelity(ϱ1prod, ϱ2) ≈ fidelity(ϱ1, ϱ2) 
-  @test fidelity(ϱ1, ϱ2prod) ≈ fidelity(ϱ1, ϱ2) 
+  @test fidelity(ψ1prod, ϱ2prod) ≈ fidelity(ψ1, ϱ2)
+  @test fidelity(ψ1prod, ϱ2) ≈ fidelity(ψ1, ϱ2)
+  @test fidelity(ψ1, ϱ2prod) ≈ fidelity(ψ1, ϱ2)
 
+  @test fidelity(ρ1prod, ρ2prod) ≈ fidelity(ρ1, ρ2)
+  @test fidelity(ρ1, ρ2prod) ≈ fidelity(ρ1, ρ2)
+  @test fidelity(ρ1prod, ρ2) ≈ fidelity(ρ1, ρ2)
+
+  @test fidelity(ρ1prod, ϱ2prod) ≈ fidelity(ρ1, ϱ2)
+  @test fidelity(ρ1, ϱ2prod) ≈ fidelity(ρ1, ϱ2)
+  @test fidelity(ρ1prod, ϱ2) ≈ fidelity(ρ1, ϱ2)
+
+  @test fidelity(ϱ1prod, ϱ2prod) ≈ fidelity(ϱ1, ϱ2)
+  @test fidelity(ϱ1prod, ϱ2) ≈ fidelity(ϱ1, ϱ2)
+  @test fidelity(ϱ1, ϱ2prod) ≈ fidelity(ϱ1, ϱ2)
 end
-
 
 @testset "quantum state fidelity: unnormalized input states" begin
   N = 4
-  sites = siteinds("Qubit",N)
+  sites = siteinds("Qubit", N)
   # MPS wavefunction
-  ψ1 = randomstate(sites; χ = 4) 
-  ψ2 = randomstate(sites; χ = 5) 
+  ψ1 = randomstate(sites; χ=4)
+  ψ2 = randomstate(sites; χ=5)
   # LPDO density matrix
-  ϱ1 = randomstate(sites; χ = 5, ξ = 2)
-  ϱ2 = randomstate(sites; χ = 5, ξ = 3)
-  
+  ϱ1 = randomstate(sites; χ=5, ξ=2)
+  ϱ2 = randomstate(sites; χ=5, ξ=3)
+
   # MPO density matrix
-  ρ1 = MPO(ϱ1) 
+  ρ1 = MPO(ϱ1)
   ρ2 = MPO(ϱ2)
 
-  ψ1vec = PastaQ.array(normalize!(copy(ψ1)))
-  ρ1mat = PastaQ.array(normalize!(copy(ρ1)))  
-  ϱ1mat = PastaQ.array(normalize!(copy(ϱ1)))
+  ψ1vec = PastaQ.array(PastaQ.normalize!(copy(ψ1)))
+  ρ1mat = PastaQ.array(PastaQ.normalize!(copy(ρ1)))
+  ϱ1mat = PastaQ.array(PastaQ.normalize!(copy(ϱ1)))
 
-  ψ2vec = PastaQ.array(normalize!(copy(ψ2)))
-  ρ2mat = PastaQ.array(normalize!(copy(ρ2)))
-  ϱ2mat = PastaQ.array(normalize!(copy(ϱ2)))
+  ψ2vec = PastaQ.array(PastaQ.normalize!(copy(ψ2)))
+  ρ2mat = PastaQ.array(PastaQ.normalize!(copy(ρ2)))
+  ϱ2mat = PastaQ.array(PastaQ.normalize!(copy(ϱ2)))
 
   @test fidelity(ψ1, ψ2) ≈ abs2(ψ1vec' * ψ2vec)
   @test fidelity(ψ1, ρ2) ≈ ψ1vec' * ρ2mat * ψ1vec
@@ -111,38 +109,37 @@ end
   ϱ1prod = prod(ϱ1)
   ϱ2prod = prod(ϱ2)
 
-  @test fidelity(ψ1prod, ψ2prod) ≈ fidelity(ψ1, ψ2)  
+  @test fidelity(ψ1prod, ψ2prod) ≈ fidelity(ψ1, ψ2)
   @test fidelity(ψ1prod, ψ2) ≈ fidelity(ψ1, ψ2)
   @test fidelity(ψ1, ψ2prod) ≈ fidelity(ψ1, ψ2)
 
-  @test fidelity(ψ1prod, ρ2prod) ≈ fidelity(ψ1, ρ2) 
-  @test fidelity(ψ1prod, ρ2) ≈ fidelity(ψ1, ρ2) 
-  @test fidelity(ψ1, ρ2prod) ≈ fidelity(ψ1, ρ2) 
-  
-  @test fidelity(ψ1prod, ϱ2prod) ≈ fidelity(ψ1, ϱ2) 
-  @test fidelity(ψ1prod, ϱ2) ≈ fidelity(ψ1, ϱ2) 
-  @test fidelity(ψ1, ϱ2prod) ≈ fidelity(ψ1, ϱ2) 
-                                           
-  @test fidelity(ρ1prod, ρ2prod) ≈ fidelity(ρ1, ρ2) 
-  @test fidelity(ρ1, ρ2prod) ≈ fidelity(ρ1, ρ2) 
-  @test fidelity(ρ1prod, ρ2) ≈ fidelity(ρ1, ρ2) 
-  
-  @test fidelity(ρ1prod, ϱ2prod) ≈ fidelity(ρ1, ϱ2) 
-  @test fidelity(ρ1, ϱ2prod) ≈ fidelity(ρ1, ϱ2) 
-  @test fidelity(ρ1prod, ϱ2) ≈ fidelity(ρ1, ϱ2) 
+  @test fidelity(ψ1prod, ρ2prod) ≈ fidelity(ψ1, ρ2)
+  @test fidelity(ψ1prod, ρ2) ≈ fidelity(ψ1, ρ2)
+  @test fidelity(ψ1, ρ2prod) ≈ fidelity(ψ1, ρ2)
 
-  @test fidelity(ϱ1prod, ϱ2prod) ≈ fidelity(ϱ1, ϱ2) 
-  @test fidelity(ϱ1prod, ϱ2) ≈ fidelity(ϱ1, ϱ2) 
-  @test fidelity(ϱ1, ϱ2prod) ≈ fidelity(ϱ1, ϱ2) 
+  @test fidelity(ψ1prod, ϱ2prod) ≈ fidelity(ψ1, ϱ2)
+  @test fidelity(ψ1prod, ϱ2) ≈ fidelity(ψ1, ϱ2)
+  @test fidelity(ψ1, ϱ2prod) ≈ fidelity(ψ1, ϱ2)
 
+  @test fidelity(ρ1prod, ρ2prod) ≈ fidelity(ρ1, ρ2)
+  @test fidelity(ρ1, ρ2prod) ≈ fidelity(ρ1, ρ2)
+  @test fidelity(ρ1prod, ρ2) ≈ fidelity(ρ1, ρ2)
+
+  @test fidelity(ρ1prod, ϱ2prod) ≈ fidelity(ρ1, ϱ2)
+  @test fidelity(ρ1, ϱ2prod) ≈ fidelity(ρ1, ϱ2)
+  @test fidelity(ρ1prod, ϱ2) ≈ fidelity(ρ1, ϱ2)
+
+  @test fidelity(ϱ1prod, ϱ2prod) ≈ fidelity(ϱ1, ϱ2)
+  @test fidelity(ϱ1prod, ϱ2) ≈ fidelity(ϱ1, ϱ2)
+  @test fidelity(ϱ1, ϱ2prod) ≈ fidelity(ϱ1, ϱ2)
 end
 
 @testset "quantum process fidelity" begin
   N = 3
-  sites = siteinds("Qubit",N)
+  sites = siteinds("Qubit", N)
 
-  circuit1 = randomcircuit(N; depth =  3)
-  circuit2 = randomcircuit(N; depth =  3)
+  circuit1 = randomcircuit(N; depth=3)
+  circuit2 = randomcircuit(N; depth=3)
   # MPO unitary 
   U1 = runcircuit(sites, circuit1; process=true)
   U2 = randomprocess(sites)
@@ -151,104 +148,103 @@ end
   ρ1 = PastaQ.choimatrix(sites, circuit1; noise=("DEP", (p=0.01,)))
   ρ2 = PastaQ.choimatrix(sites, circuit2; noise=("DEP", (p=0.01,)))
   # LPDO Choi matrix
-  ϱ1 = normalize!(randomprocess(sites; mixed=true))
-  ϱ2 = normalize!(randomprocess(sites; mixed=true))
+  ϱ1 = PastaQ.normalize!(randomprocess(sites; mixed=true))
+  ϱ2 = PastaQ.normalize!(randomprocess(sites; mixed=true))
 
   @disable_warn_order begin
     ϕ1 = PastaQ.unitary_mpo_to_choi_mps(U1)
-    normalize!(ϕ1)
+    PastaQ.normalize!(ϕ1)
     ϕ1vec = PastaQ.array(ϕ1)
     ρ1mat = PastaQ.array(ρ1)
     ρ1mat = ρ1mat / tr(ρ1mat)
     ϱ1mat = PastaQ.array(ϱ1)
     ϱ1mat = ϱ1mat / tr(ϱ1mat)
-    
+
     ϕ2 = PastaQ.unitary_mpo_to_choi_mps(U2)
-    normalize!(ϕ2)
+    PastaQ.normalize!(ϕ2)
     ϕ2vec = PastaQ.array(ϕ2)
     ρ2mat = PastaQ.array(ρ2)
     ρ2mat = ρ2mat / tr(ρ2mat)
     ϱ2mat = PastaQ.array(ϱ2)
     ϱ2mat = ϱ2mat / tr(ϱ2mat)
-    
-    
+
     @test fidelity(U1, U2; process=true) ≈ abs2(ϕ1vec' * ϕ2vec)
     @test fidelity(U1, ρ2; process=true) ≈ ϕ1vec' * ρ2mat * ϕ1vec
     @test fidelity(U1, ϱ2; process=true) ≈ (ϕ1vec' * ϱ2mat * ϕ1vec)
 
     @test fidelity(ρ1, ρ2; process=true) ≈
-          real(tr(sqrt(sqrt(ρ1mat) * ρ2mat * sqrt(ρ1mat))))^2 atol = 1e-7
+      real(tr(sqrt(sqrt(ρ1mat) * ρ2mat * sqrt(ρ1mat))))^2 atol = 1e-7
     @test fidelity(ρ1, ϱ2; process=true) ≈
-          real(tr(sqrt(sqrt(ρ1mat) * ϱ2mat * sqrt(ρ1mat))))^2 atol = 1e-7
-    @test fidelity(ϱ1, ϱ2; process=true, cutoff = 1e-14) ≈
-          real(tr(sqrt(sqrt(ϱ1mat) * ϱ2mat * sqrt(ϱ1mat))))^2 atol = 1e-7
+      real(tr(sqrt(sqrt(ρ1mat) * ϱ2mat * sqrt(ρ1mat))))^2 atol = 1e-7
+    @test fidelity(ϱ1, ϱ2; process=true, cutoff=1e-14) ≈
+      real(tr(sqrt(sqrt(ϱ1mat) * ϱ2mat * sqrt(ϱ1mat))))^2 atol = 1e-7
 
     # ITensors
-    U1prod = prod(U1) 
-    U2prod = prod(U2) 
+    U1prod = prod(U1)
+    U2prod = prod(U2)
     ρ1prod = prod(ρ1)
     ρ2prod = prod(ρ2)
     ϱ1prod = prod(ϱ1)
     ϱ2prod = prod(ϱ2)
 
-    @test fidelity(U1prod, U2prod; process=true) ≈ fidelity(U1, U2; process=true)  
-    @test fidelity(U1, U2prod; process=true) ≈ fidelity(U1, U2; process=true)  
-    @test fidelity(U1prod, U2; process=true) ≈ fidelity(U1, U2; process=true)  
-    
-    @test fidelity(U1prod, ρ2prod; process=true) ≈ fidelity(U1, ρ2; process=true) 
-    @test fidelity(U1, ρ2prod; process=true) ≈ fidelity(U1, ρ2; process=true) 
-    @test fidelity(U1prod, ρ2; process=true) ≈ fidelity(U1, ρ2; process=true) 
-    
-    @test fidelity(U1prod, ϱ2prod; process=true) ≈ fidelity(U1, ϱ2; process=true) 
-    @test fidelity(U1prod, ϱ2; process=true) ≈ fidelity(U1, ϱ2; process=true) 
-    @test fidelity(U1, ϱ2prod; process=true) ≈ fidelity(U1, ϱ2; process=true) 
+    @test fidelity(U1prod, U2prod; process=true) ≈ fidelity(U1, U2; process=true)
+    @test fidelity(U1, U2prod; process=true) ≈ fidelity(U1, U2; process=true)
+    @test fidelity(U1prod, U2; process=true) ≈ fidelity(U1, U2; process=true)
+
+    @test fidelity(U1prod, ρ2prod; process=true) ≈ fidelity(U1, ρ2; process=true)
+    @test fidelity(U1, ρ2prod; process=true) ≈ fidelity(U1, ρ2; process=true)
+    @test fidelity(U1prod, ρ2; process=true) ≈ fidelity(U1, ρ2; process=true)
+
+    @test fidelity(U1prod, ϱ2prod; process=true) ≈ fidelity(U1, ϱ2; process=true)
+    @test fidelity(U1prod, ϱ2; process=true) ≈ fidelity(U1, ϱ2; process=true)
+    @test fidelity(U1, ϱ2prod; process=true) ≈ fidelity(U1, ϱ2; process=true)
   end
 end
 
 @testset "quantum process fidelity: unnormalized states" begin
   N = 3
-  sites = siteinds("Qubit",N)
+  sites = siteinds("Qubit", N)
 
-  circuit1 = randomcircuit(N; depth =  3)
-  circuit2 = randomcircuit(N; depth =  3)
+  circuit1 = randomcircuit(N; depth=3)
+  circuit2 = randomcircuit(N; depth=3)
   # MPO unitary 
-  U1 = randomprocess(sites; χ = 3) 
-  U2 = randomprocess(sites; χ = 4)
+  U1 = randomprocess(sites; χ=3)
+  U2 = randomprocess(sites; χ=4)
 
   # LPDO Choi matrix
-  ϱ1 = randomprocess(sites; ξ = 3, χ = 2)
-  ϱ2 = randomprocess(sites; ξ = 3, χ = 3)
+  ϱ1 = randomprocess(sites; ξ=3, χ=2)
+  ϱ2 = randomprocess(sites; ξ=3, χ=3)
 
   @disable_warn_order begin
     ϕ1 = PastaQ.unitary_mpo_to_choi_mps(U1)
-    normalize!(ϕ1)
+    PastaQ.normalize!(ϕ1)
     ϕ1vec = PastaQ.array(ϕ1)
     ϱ1mat = PastaQ.array(ϱ1)
     ϱ1mat = ϱ1mat / tr(ϱ1mat)
-    
+
     ϕ2 = PastaQ.unitary_mpo_to_choi_mps(U2)
-    normalize!(ϕ2)
+    PastaQ.normalize!(ϕ2)
     ϕ2vec = PastaQ.array(ϕ2)
     ϱ2mat = PastaQ.array(ϱ2)
     ϱ2mat = ϱ2mat / tr(ϱ2mat)
-    
+
     @test fidelity(U1, U2; process=true) ≈ abs2(ϕ1vec' * ϕ2vec)
     @test fidelity(U1, ϱ2; process=true) ≈ (ϕ1vec' * ϱ2mat * ϕ1vec)
     @test fidelity(ϱ1, ϱ2; process=true) ≈
-          real(tr(sqrt(sqrt(ϱ1mat) * ϱ2mat * sqrt(ϱ1mat))))^2 atol = 1e-7
+      real(tr(sqrt(sqrt(ϱ1mat) * ϱ2mat * sqrt(ϱ1mat))))^2 atol = 1e-7
 
     ## ITensors
-    U1prod = prod(U1) 
-    U2prod = prod(U2) 
+    U1prod = prod(U1)
+    U2prod = prod(U2)
     ϱ1prod = prod(ϱ1)
     ϱ2prod = prod(ϱ2)
 
-    @test fidelity(U1prod, U2prod; process=true) ≈ fidelity(U1, U2; process=true)  
-    @test fidelity(U1, U2prod; process=true) ≈ fidelity(U1, U2; process=true)  
-    @test fidelity(U1prod, U2; process=true) ≈ fidelity(U1, U2; process=true)  
-    
-    @test fidelity(U1prod, ϱ2prod; process=true) ≈ fidelity(U1, ϱ2; process=true) 
-    @test fidelity(U1, ϱ2prod; process=true) ≈ fidelity(U1, ϱ2; process=true) 
+    @test fidelity(U1prod, U2prod; process=true) ≈ fidelity(U1, U2; process=true)
+    @test fidelity(U1, U2prod; process=true) ≈ fidelity(U1, U2; process=true)
+    @test fidelity(U1prod, U2; process=true) ≈ fidelity(U1, U2; process=true)
+
+    @test fidelity(U1prod, ϱ2prod; process=true) ≈ fidelity(U1, ϱ2; process=true)
+    @test fidelity(U1, ϱ2prod; process=true) ≈ fidelity(U1, ϱ2; process=true)
   end
 end
 

--- a/test/fulltomography.jl
+++ b/test/fulltomography.jl
@@ -6,9 +6,9 @@ using Random
 
 @testset " counts and frequencies" begin
   N = 3
-  d = 1<<N
-  gates = randomcircuit(N; depth = 4)
-  ψ = runcircuit(N,gates)
+  d = 1 << N
+  gates = randomcircuit(N; depth=4)
+  ψ = runcircuit(N, gates)
 
   bases = fullbases(N)
   samples = getsamples(ψ, bases, 100)
@@ -21,9 +21,9 @@ using Random
   @test length(keys(probs2)) == 3^N
   @test probs1 == probs2
 
-  for (basis,counts_in_basis) in C
+  for (basis, counts_in_basis) in C
     tot_counts = sum(values(counts_in_basis))
-    for (proj,counts) in counts_in_basis
+    for (proj, counts) in counts_in_basis
       freq = counts / tot_counts
       @test freq ≈ probs1[basis][proj]
     end
@@ -32,9 +32,9 @@ end
 
 @testset "POVM matrix" begin
   N = 3
-  d = 1<<N
-  gates = randomcircuit(N,; depth = 4)
-  ψ = runcircuit(N,gates)
+  d = 1 << N
+  gates = randomcircuit(N, ; depth=4)
+  ψ = runcircuit(N, gates)
 
   bases = fullbases(N)
   samples = getsamples(ψ, bases, 100)
@@ -45,134 +45,131 @@ end
   ρ_vec = vec(ρmat)
 
   probs = PastaQ.empirical_probabilities(samples)
-  A = PastaQ.design_matrix(probs; return_probs = false)
+  A = PastaQ.design_matrix(probs; return_probs=false)
   real_probs = A * ρ_vec
   ρ̂_vec = pinv(A) * real_probs
-  ρ̂ = reshape(ρ̂_vec,(d,d))
+  ρ̂ = reshape(ρ̂_vec, (d, d))
   @test ρmat ≈ ρ̂
 end
 
-
 @testset "make PSD" begin
-  ρ = zeros(5,5)
-  ρ[1,1] = 3/5; ρ[2,2] = 1/2; ρ[3,3] = 7/20;
-  ρ[4,4] = 1/10; ρ[5,5] = -11/20;
+  ρ = zeros(5, 5)
+  ρ[1, 1] = 3 / 5
+  ρ[2, 2] = 1 / 2
+  ρ[3, 3] = 7 / 20
+  ρ[4, 4] = 1 / 10
+  ρ[5, 5] = -11 / 20
 
   ρ̂ = PastaQ.make_PSD(ρ)
   λ = reverse(first(eigen(ρ̂)))
-  @test λ[1] ≈ 9/20
-  @test λ[2] ≈ 7/20
-  @test λ[3] ≈ 1/5
+  @test λ[1] ≈ 9 / 20
+  @test λ[2] ≈ 7 / 20
+  @test λ[3] ≈ 1 / 5
   @test λ[4] ≈ 0.0
   @test λ[5] ≈ 0.0
 end
 
 @testset "PSD constraint in QST" begin
   N = 2
-  d = 1<<N
-  gates = randomcircuit(N; depth = 4)
-  ψ = runcircuit(N,gates)
+  d = 1 << N
+  gates = randomcircuit(N; depth=4)
+  ψ = runcircuit(N, gates)
 
   bases = fullbases(N)
   samples = getsamples(ψ, bases, 100)
 
   ϱ = PastaQ.array(MPO(ψ))
 
-  ρ = PastaQ.array(tomography(samples; method = "LI"))
+  ρ = PastaQ.array(tomography(samples; method="LI"))
   λ = first(eigen(ρ))
   @test all(λ .≥ -1e-4)
 
-  ρ = PastaQ.array(tomography(samples; method = "LS"))
+  ρ = PastaQ.array(tomography(samples; method="LS"))
   λ = first(eigen(ρ))
   @test all(real(λ) .≥ -1e-4)
 
-  ρ = PastaQ.array(tomography(samples; method = "MLE"))
+  ρ = PastaQ.array(tomography(samples; method="MLE"))
   λ = first(eigen(ρ))
-  @test all(real(λ) .≥-1e-4)
+  @test all(real(λ) .≥ -1e-4)
 end
 
 @testset "arbitrary trace in QST" begin
   N = 2
-  d = 1<<N
-  gates = randomcircuit(N; depth = 4)
-  ψ = runcircuit(N,gates)
+  d = 1 << N
+  gates = randomcircuit(N; depth=4)
+  ψ = runcircuit(N, gates)
 
   bases = fullbases(N)
   samples = getsamples(ψ, bases, 100)
 
   ϱ = PastaQ.array(MPO(ψ))
 
-  ρ = PastaQ.array(tomography(samples; method = "LI", trρ = 2.0))
+  ρ = PastaQ.array(tomography(samples; method="LI", trρ=2.0))
   @test tr(ρ) ≈ 2.0
-  ρ = PastaQ.array(tomography(samples; method = "LS", trρ = 2.0))
+  ρ = PastaQ.array(tomography(samples; method="LS", trρ=2.0))
   @test tr(ρ) ≈ 2.0 atol = 1e-4
-  ρ = PastaQ.array(tomography(samples; method = "MLE", trρ = 2.0))
+  ρ = PastaQ.array(tomography(samples; method="MLE", trρ=2.0))
   @test tr(ρ) ≈ 2.0 atol = 1e-4
 end
 
-
-
 @testset "Choi POVM matrix" begin
   N = 2
-  d = 2^(2*N)
+  d = 2^(2 * N)
   nshots = 3
-  gates = randomcircuit(N; depth = 2)
-  
-  Λ = runcircuit(gates; process = true,noise = ("DEP",(p=0.001,)))
+  gates = randomcircuit(N; depth=2)
+
+  Λ = runcircuit(gates; process=true, noise=("DEP", (p=0.001,)))
   preps = fullpreparations(N)
   bases = fullbases(N)
   data = getsamples(Λ, preps, bases, nshots)
 
   Λmat = PastaQ.array(Λ)
   Λvec = vec(Λmat)
-  
+
   probs = PastaQ.empirical_probabilities(data)
-  A = PastaQ.design_matrix(probs; return_probs = false, process = true)
+  A = PastaQ.design_matrix(probs; return_probs=false, process=true)
   real_probs = A * Λvec
   Λ̂vec = pinv(A) * real_probs
-  Λ̂ = reshape(Λ̂vec,(d,d))
+  Λ̂ = reshape(Λ̂vec, (d, d))
   @test Λmat ≈ Λ̂
 end
 
-
 @testset "PSD constraint in QPT" begin
   N = 2
-  d = 1<<N
+  d = 1 << N
   nshots = 3
-  gates = randomcircuit(N; depth = 4)
-  Λ = runcircuit(gates; process = true,noise = ("DEP",(p=0.001,)))
+  gates = randomcircuit(N; depth=4)
+  Λ = runcircuit(gates; process=true, noise=("DEP", (p=0.001,)))
   preps = fullpreparations(N)
   bases = fullbases(N)
   data = getsamples(Λ, preps, bases, nshots)
 
-  ρ = PastaQ.array(tomography(data; method = "LI"))
+  ρ = PastaQ.array(tomography(data; method="LI"))
   λ = first(eigen(ρ))
   @test all(λ .≥ -1e-4)
 
-  ρ = PastaQ.array(tomography(data; method = "LS"))
+  ρ = PastaQ.array(tomography(data; method="LS"))
   λ = first(eigen(ρ))
   @test all(real(λ) .≥ -1e-4)
-
 end
 
 @testset "Trace preserving condition in QPT" begin
   Random.seed!(1234)
   N = 2
-  d = 1<<N
+  d = 1 << N
   nshots = 3
-  gates = randomcircuit(N; depth = 4)
-  Λ = runcircuit(gates; process = true,noise = ("DEP",(p=0.001,)))
+  gates = randomcircuit(N; depth=4)
+  Λ = runcircuit(gates; process=true, noise=("DEP", (p=0.001,)))
   preps = fullpreparations(N)
   bases = fullbases(N)
   data = getsamples(Λ, preps, bases, nshots)
 
-  ρ = tomography(data; method = "LS")
+  ρ = tomography(data; method="LS")
   for j in 1:N
-    s = firstind(ρ, tags="Output,n=$(j)", plev=0)
-    ρ = ρ * δ(s,s')
+    s = firstind(ρ; tags="Output,n=$(j)", plev=0)
+    ρ = ρ * δ(s, s')
   end
-  
-  ρmat = PastaQ.array(ρ)
-  @test ρmat ≈ Matrix{Float64}(I,d,d) atol = 1e-5
-end
 
+  ρmat = PastaQ.array(ρ)
+  @test ρmat ≈ Matrix{Float64}(I, d, d) atol = 1e-5
+end

--- a/test/gates.jl
+++ b/test/gates.jl
@@ -4,8 +4,8 @@ using Test
 using LinearAlgebra
 
 @testset "Gate generation: 1-qubit gates" begin
-  i = Index(2, tags = "Qubit")
-  
+  i = Index(2; tags="Qubit")
+
   g = gate("I", i)
   @test plev(inds(g)[1]) == 1
   @test plev(inds(g)[2]) == 0
@@ -17,32 +17,32 @@ using LinearAlgebra
   @test plev(inds(g)[2]) == 0
   ggdag = g * prime(dag(g), 1; plev=1)
   @test ITensors.array(ggdag) ≈ Matrix{Int}(I, 2, 2)
-  @test g ≈ gate("σx",i)
-  @test g ≈ gate("σ1",i)
+  @test g ≈ gate("σx", i)
+  @test g ≈ gate("σ1", i)
 
   g = gate("Y", i)
   @test plev(inds(g)[1]) == 1
   @test plev(inds(g)[2]) == 0
   ggdag = g * prime(dag(g), 1; plev=1)
   @test ITensors.array(ggdag) ≈ Matrix{Int}(I, 2, 2)
-  @test g ≈ gate("σy",i)
-  @test g ≈ gate("σ2",i)
+  @test g ≈ gate("σy", i)
+  @test g ≈ gate("σ2", i)
 
   g = gate("Z", i)
   @test plev(inds(g)[1]) == 1
   @test plev(inds(g)[2]) == 0
   ggdag = g * prime(dag(g), 1; plev=1)
   @test ITensors.array(ggdag) ≈ Matrix{Int}(I, 2, 2)
-  @test g ≈ gate("σz",i)
-  @test g ≈ gate("σ3",i)
+  @test g ≈ gate("σz", i)
+  @test g ≈ gate("σ3", i)
 
   g = gate("√X", i)
   @test plev(inds(g)[1]) == 1
   @test plev(inds(g)[2]) == 0
   ggdag = g * prime(dag(g), 1; plev=1)
   @test ITensors.array(ggdag) ≈ Matrix{Int}(I, 2, 2)
-  @test g ≈ gate("√NOT",i)
-  
+  @test g ≈ gate("√NOT", i)
+
   g = gate("H", i)
   @test plev(inds(g)[1]) == 1
   @test plev(inds(g)[2]) == 0
@@ -54,7 +54,7 @@ using LinearAlgebra
   @test plev(inds(g)[2]) == 0
   ggdag = g * prime(dag(g), 1; plev=1)
   @test ITensors.array(ggdag) ≈ Matrix{Int}(I, 2, 2)
-  @test g ≈ gate("P",i)
+  @test g ≈ gate("P", i)
 
   g = gate("T", i)
   @test plev(inds(g)[1]) == 1
@@ -136,7 +136,7 @@ end
   @test ITensors.array(ggdag) ≈ reshape(Matrix{ComplexF64}(I, 4, 4), (2, 2, 2, 2))
   @test g ≈ gate("√Swap", i, j)
   @test g ≈ gate("√Sw", i, j)
-  
+
   g = gate("iSWAP", i, j)
   @test plev(inds(g)[1]) == 1 && plev(inds(g)[2]) == 1
   @test plev(inds(g)[3]) == 0 && plev(inds(g)[4]) == 0
@@ -162,50 +162,48 @@ end
   ggdag = g * prime(dag(g), 1; plev=1)
   @test ITensors.array(ggdag) ≈ reshape(Matrix{ComplexF64}(I, 4, 4), (2, 2, 2, 2))
 
-  g = gate("CRz", i, j; ϕ = ϕ)
+  g = gate("CRz", i, j; ϕ=ϕ)
   @test plev(inds(g)[1]) == 1 && plev(inds(g)[2]) == 1
   @test plev(inds(g)[3]) == 0 && plev(inds(g)[4]) == 0
   ggdag = g * prime(dag(g), 1; plev=1)
   @test ITensors.array(ggdag) ≈ reshape(Matrix{ComplexF64}(I, 4, 4), (2, 2, 2, 2))
-  
+
   g = gate("CRn", i, j; θ=θ, ϕ=ϕ, λ=λ)
   @test plev(inds(g)[1]) == 1 && plev(inds(g)[2]) == 1
   @test plev(inds(g)[3]) == 0 && plev(inds(g)[4]) == 0
   ggdag = g * prime(dag(g), 1; plev=1)
   @test ITensors.array(ggdag) ≈ reshape(Matrix{ComplexF64}(I, 4, 4), (2, 2, 2, 2))
   @test g ≈ gate("CRn̂", i, j; θ=θ, ϕ=ϕ, λ=λ)
-end 
-  
+end
+
 @testset "Gate generation: 3-qubit gates" begin
   i = Index(2)
   j = Index(2)
   k = Index(2)
-  
+
   g = gate("Toffoli", i, j, k)
-  @test plev(inds(g)[1]) == 1 && plev(inds(g)[2]) == 1 && plev(inds(g)[3]) == 1 
+  @test plev(inds(g)[1]) == 1 && plev(inds(g)[2]) == 1 && plev(inds(g)[3]) == 1
   @test plev(inds(g)[4]) == 0 && plev(inds(g)[5]) == 0 && plev(inds(g)[6]) == 0
   ggdag = g * prime(dag(g), 1; plev=1)
   @test ITensors.array(ggdag) ≈ reshape(Matrix{ComplexF64}(I, 8, 8), (2, 2, 2, 2, 2, 2))
   @test g ≈ gate("CCNOT", i, j, k)
   @test g ≈ gate("CCX", i, j, k)
   @test g ≈ gate("TOFF", i, j, k)
-  
+
   g = gate("Fredkin", i, j, k)
-  @test plev(inds(g)[1]) == 1 && plev(inds(g)[2]) == 1 && plev(inds(g)[3]) == 1 
+  @test plev(inds(g)[1]) == 1 && plev(inds(g)[2]) == 1 && plev(inds(g)[3]) == 1
   @test plev(inds(g)[4]) == 0 && plev(inds(g)[5]) == 0 && plev(inds(g)[6]) == 0
   ggdag = g * prime(dag(g), 1; plev=1)
   @test ITensors.array(ggdag) ≈ reshape(Matrix{ComplexF64}(I, 8, 8), (2, 2, 2, 2, 2, 2))
   @test g ≈ gate("CSWAP", i, j, k)
   @test g ≈ gate("CSwap", i, j, k)
   @test g ≈ gate("CSw", i, j, k)
-
 end
-
 
 @testset "Gate generation: Haar gates" begin
   i = Index(2)
   j = Index(2)
-  
+
   g = gate("randU", i)
   @test hasinds(g, i', i)
   Id = g * swapprime(dag(g)', 2 => 1)
@@ -228,7 +226,7 @@ end
     end
   end
 
-@testset "Custom gate with long name" begin
+  @testset "Custom gate with long name" begin
     PastaQ.gate(::GateName"my_favorite_gate") = [0.11 0.12; 0.21 0.22]
     s = Index(2, "Qubit, Site")
     gate("my_favorite_gate", s)
@@ -241,24 +239,21 @@ end
 end
 
 @testset "Bases rotations" begin
+  zp = [1.0, 0.0]
+  zm = [0.0, 1.0]
+  xp = [1.0, 1.0] / √2
+  xm = [1.0, -1.0] / √2
+  yp = [1.0, im] / √2
+  ym = [1.0, -im] / √2
 
-  zp = [1.0,0.0]
-  zm = [0.0,1.0]
-  xp = [1.0,1.0]/√2
-  xm = [1.0,-1.0]/√2
-  yp = [1.0,im]/√2
-  ym = [1.0,-im]/√2
-
-  Ux = gate("basisX"; dag = true)
+  Ux = gate("basisX"; dag=true)
   @test Ux * xp ≈ zp
   @test Ux * xm ≈ zm
 
-  Ux = gate("basisY"; dag = true)
+  Ux = gate("basisY"; dag=true)
   @test Ux * yp ≈ zp
   @test Ux * ym ≈ zm
-
 end
-
 
 @testset "apply gate: Id" begin
   psi = productstate(2)
@@ -381,7 +376,7 @@ end
   gate_data = ("Rn", 1, (θ=θ, ϕ=ϕ, λ=λ))
   psi = runcircuit(psi, gate_data)
   @test PastaQ.array(psi[1]) ≈
-        [-exp(im * λ) * sin(θ / 2.0), exp(im * (ϕ + λ)) * cos(θ / 2.0)]
+    [-exp(im * λ) * sin(θ / 2.0), exp(im * (ϕ + λ)) * cos(θ / 2.0)]
 end
 
 @testset "apply gate: prep X+/X-" begin
@@ -671,94 +666,87 @@ end
   @test psi_vec ≈ [0.0, 0.0, 0.0, 1.0]
 end
 
-
 @testset "function applied to a gate" begin
   s = siteinds("Qubit", 2)
-  
-  θ = 0.1
-  rx = gate("Rx"; θ = 0.1)
-  exp_rx = exp(rx)
-  gtest = gate("Rx",s[1]; θ = 0.1, f = x -> exp(x))
-  @test PastaQ.array(gtest) ≈ exp_rx
-  
-  cx = 0.1*gate("CX")
-  exp_cx = exp(cx)
-  gtest = gate("CX",s[1],s[2]; f = x -> exp(0.1*x))
-  @test PastaQ.array(gtest) ≈ exp_cx
 
+  θ = 0.1
+  rx = gate("Rx"; θ=0.1)
+  exp_rx = exp(rx)
+  gtest = gate("Rx", s[1]; θ=0.1, f=x -> exp(x))
+  @test PastaQ.array(gtest) ≈ exp_rx
+
+  cx = 0.1 * gate("CX")
+  exp_cx = exp(cx)
+  gtest = gate("CX", s[1], s[2]; f=x -> exp(0.1 * x))
+  @test PastaQ.array(gtest) ≈ exp_cx
 end
 
-
 @testset "gate built out of elementary gates" begin
-  
   s = siteinds("Qubit", 2)
-  
-  G = gate("S") * gate("S") 
+
+  G = gate("S") * gate("S")
   gtest = gate("S * S", s[1])
-  @test PastaQ.array(gtest) ≈ G 
-  
+  @test PastaQ.array(gtest) ≈ G
+
   cx = gate("CX")
-  
+
   G = cx * cx * cx
-  gtest = gate("CX*CX*CX", s[1],s[2])
-  @test PastaQ.array(gtest) ≈ G 
-  
+  gtest = gate("CX*CX*CX", s[1], s[2])
+  @test PastaQ.array(gtest) ≈ G
+
   G = gate("S") + gate("T")
   gtest = gate("S + T", s[1])
   @test PastaQ.array(gtest) ≈ G
-  
+
   G = gate("S") + gate("T") * gate("X")
   gtest = gate("S + T * X", s[1])
   @test PastaQ.array(gtest) ≈ G
-  
+
   G = gate("S") + gate("T") * gate("X") * gate("Y")
   gtest = gate("S + T * X * Y", s[1])
   @test PastaQ.array(gtest) ≈ G
-  
-  G = gate("Z")*gate("S") + gate("T") * gate("X") * gate("Y")
+
+  G = gate("Z") * gate("S") + gate("T") * gate("X") * gate("Y")
   gtest = gate("Z*S + T * X * Y", s[1])
   @test PastaQ.array(gtest) ≈ G
 
-
-  exp_cx = exp(0.1*cx)
-  gtest = gate("CX",s[1],s[2]; f = x -> exp(0.1*x))
+  exp_cx = exp(0.1 * cx)
+  gtest = gate("CX", s[1], s[2]; f=x -> exp(0.1 * x))
   @test PastaQ.array(gtest) ≈ exp_cx
-  
+
   d = 3
-  q = siteinds("Qudit", 4; dim = d)
-  g1 = gate("a†a", q[1]; f = x -> exp(0.1*x))
-  g2 = gate("a† * a", q[1]; f = x -> exp(0.1*x))
+  q = siteinds("Qudit", 4; dim=d)
+  g1 = gate("a†a", q[1]; f=x -> exp(0.1 * x))
+  g2 = gate("a† * a", q[1]; f=x -> exp(0.1 * x))
   @test g1 ≈ g2
 end
 
-
-
 @testset "qudit gates" begin
   dim = 3
-  s = siteinds("Qudit", 4; dim = dim)
+  s = siteinds("Qudit", 4; dim=dim)
   dims = (dim,)
-  @test gate("a†", dims)      ≈ [0 0 0; 1 0 0; 0 √2 0] 
-  @test gate("a", dims)       ≈ [0 1 0; 0 0 √2; 0 0 0]  
+  @test gate("a†", dims) ≈ [0 0 0; 1 0 0; 0 √2 0]
+  @test gate("a", dims) ≈ [0 1 0; 0 0 √2; 0 0 0]
 
-  @test gate("a†", dims) * gate("a", dims) ≈ [0 0 0; 0 1 0; 0 0 2] 
+  @test gate("a†", dims) * gate("a", dims) ≈ [0 0 0; 0 1 0; 0 0 2]
 
   @test PastaQ.array(gate("a†", s[1])) ≈ [0 0 0; 1 0 0; 0 √2 0]
-  @test PastaQ.array(gate("a", s[1])) ≈ [0 1 0; 0 0 √2; 0 0 0] 
-  
+  @test PastaQ.array(gate("a", s[1])) ≈ [0 1 0; 0 0 √2; 0 0 0]
+
   @test PastaQ.array(gate("a†a", s[1])) ≈ [0 0 0; 0 1 0; 0 0 2]
   @test PastaQ.array(gate("aa†", s[1])) ≈ [1 0 0; 0 2 0; 0 0 0]
   @test PastaQ.array(gate("a† * a", s[1])) ≈ [0 0 0; 0 1 0; 0 0 2]
   @test PastaQ.array(gate("a * a†", s[1])) ≈ [1 0 0; 0 2 0; 0 0 0]
-  
 
   dim = 10
-  s = siteinds("Qudit", 4; dim = dim)
+  s = siteinds("Qudit", 4; dim=dim)
   dims = (dim,)
-  @test PastaQ.array(gate("a† * a† * a * a", s[1])) ≈ gate("a†", dims)  * gate("a†", dims)  * gate("a", dims) * gate("a", dims)
-  
+  @test PastaQ.array(gate("a† * a† * a * a", s[1])) ≈
+    gate("a†", dims) * gate("a†", dims) * gate("a", dims) * gate("a", dims)
+
   @test PastaQ.array(gate("a†a", s[1], s[2])) ≈ kron(gate("a†", dims), gate("a", dims))
   @test PastaQ.array(gate("aa†", s[1], s[2])) ≈ kron(gate("a", dims), gate("a†", dims))
-  
-  @test PastaQ.array(gate("a†a+aa†", s[1], s[2])) ≈ kron(gate("a†", dims), gate("a", dims)) + kron(gate("a", dims), gate("a†", dims))
-end
 
+  @test PastaQ.array(gate("a†a+aa†", s[1], s[2])) ≈
+    kron(gate("a†", dims), gate("a", dims)) + kron(gate("a", dims), gate("a†", dims))
+end

--- a/test/getsamples.jl
+++ b/test/getsamples.jl
@@ -44,7 +44,7 @@ end
 
   bases = fullbases(N)
   @test bases isa Matrix{String}
-  @test size(bases) == (3^N,N)
+  @test size(bases) == (3^N, N)
 end
 
 @testset "measurements" begin
@@ -52,7 +52,7 @@ end
   N = 3
   depth = 4
   ψ0 = productstate(N)
-  gates = randomcircuit(N; depth =  depth)
+  gates = randomcircuit(N; depth=depth)
   ψ = runcircuit(ψ0, gates)
   ψ_vec = PastaQ.array(ψ)
   probs = abs2.(ψ_vec)
@@ -63,7 +63,7 @@ end
   @test size(samples)[2] == N
   data_prob = empiricalprobability(samples)
   @test probs ≈ data_prob atol = 1e-2
-  
+
   ρ = runcircuit(N, gates; noise=("amplitude_damping", (γ=0.01,)))
   ρ_mat = PastaQ.array(ρ)
   probs = real(diag(ρ_mat))
@@ -76,32 +76,31 @@ end
 end
 
 @testset "basis rotations" begin
-  s = siteinds("Qubit",1)
+  s = siteinds("Qubit", 1)
   #ϕ = qubits(1)
-  ψ0 = state("X+",s[1])
-  gates = [("basisX",1,(dag=true,))]
-  ψ = runcircuit(ψ0,gates)
+  ψ0 = state("X+", s[1])
+  gates = [("basisX", 1, (dag=true,))]
+  ψ = runcircuit(ψ0, gates)
   @test PastaQ.array(ψ) ≈ state("Z+")
-  ψ0 = state("X-",s[1])
-  gates = [("basisX",1,(dag=true,))]
-  ψ = runcircuit(ψ0,gates)
+  ψ0 = state("X-", s[1])
+  gates = [("basisX", 1, (dag=true,))]
+  ψ = runcircuit(ψ0, gates)
   @test PastaQ.array(ψ) ≈ state("Z-")
 
-  ψ0 = state("Y+",s[1])
-  gates = [("basisY",1,(dag=true,))]
-  ψ = runcircuit(ψ0,gates)
+  ψ0 = state("Y+", s[1])
+  gates = [("basisY", 1, (dag=true,))]
+  ψ = runcircuit(ψ0, gates)
   @test PastaQ.array(ψ) ≈ state("Z+")
-  ψ0 = state("Y-",s[1])
-  gates = [("basisY",1,(dag=true,))]
-  ψ = runcircuit(ψ0,gates)
+  ψ0 = state("Y-", s[1])
+  gates = [("basisY", 1, (dag=true,))]
+  ψ = runcircuit(ψ0, gates)
   @test PastaQ.array(ψ) ≈ state("Z-")
 end
-
 
 @testset "project unitary MPO" begin
   N = 4
   ntrial = 100
-  gates = randomcircuit(N; depth =  4, layered=false)
+  gates = randomcircuit(N; depth=4, layered=false)
 
   U = runcircuit(N, gates; process=true)
 
@@ -125,9 +124,9 @@ end
 @testset "project unitary ITensor" begin
   N = 4
   ntrial = 100
-  gates = randomcircuit(N; depth =  4, layered=false)
+  gates = randomcircuit(N; depth=4, layered=false)
 
-  U = runcircuit(N, gates; process=true, full_representation = true)
+  U = runcircuit(N, gates; process=true, full_representation=true)
 
   bases = randombases(N, ntrial)
   preps = randompreparations(N, ntrial)
@@ -149,7 +148,7 @@ end
 @testset "project Choi MPO" begin
   N = 4
   ntrial = 100
-  gates = randomcircuit(N; depth =  4, layered=false)
+  gates = randomcircuit(N; depth=4, layered=false)
 
   Λ = runcircuit(N, gates; process=true, noise=("amplitude_damping", (γ=0.1,)))
 
@@ -172,10 +171,16 @@ end
 @testset "project Choi ITensor" begin
   N = 4
   ntrial = 100
-  gates = randomcircuit(N; depth =  4, layered=false)
+  gates = randomcircuit(N; depth=4, layered=false)
 
   @disable_warn_order begin
-    Λ = runcircuit(N, gates; process=true, noise=("amplitude_damping", (γ=0.1,)), full_representation = true)
+    Λ = runcircuit(
+      N,
+      gates;
+      process=true,
+      noise=("amplitude_damping", (γ=0.1,)),
+      full_representation=true,
+    )
 
     bases = randombases(N, ntrial)
     preps = PastaQ.randompreparations(N, ntrial)
@@ -194,178 +199,178 @@ end
   end
 end
 
-
-
-
-
-
 @testset "getsamples: states" begin
   N = 3
-  circuit = randomcircuit(N; depth = 3)
-  
+  circuit = randomcircuit(N; depth=3)
+
   # quantum states
   ψ = runcircuit(N, circuit)
   ρ = runcircuit(N, circuit; noise=("amplitude_damping", (γ=0.1,)))
-  
+
   nbases = 11
   bases = randombases(N, nbases)
   data = getsamples(ψ, bases)
-  @test size(data) == (nbases,N)
+  @test size(data) == (nbases, N)
   nshots = 3
   data = getsamples(ψ, bases, nshots)
-  @test size(data) == (nbases*nshots,N)
+  @test size(data) == (nbases * nshots, N)
   for b in 1:nbases
     for k in 1:nshots
-      @test first.(data[(b-1)*nshots+k,:]) == bases[b,:]
+      @test first.(data[(b - 1) * nshots + k, :]) == bases[b, :]
     end
   end
 
   data = getsamples(ρ, bases)
-  @test size(data) == (nbases,N)
+  @test size(data) == (nbases, N)
   nshots = 3
   data = getsamples(ρ, bases, nshots)
-  @test size(data) == (nbases*nshots,N)
+  @test size(data) == (nbases * nshots, N)
   for b in 1:nbases
     for k in 1:nshots
-      @test first.(data[(b-1)*nshots+k,:]) == bases[b,:]
+      @test first.(data[(b - 1) * nshots + k, :]) == bases[b, :]
     end
   end
-  
+
   # ITensors quantum states
-  ψ = runcircuit(N, circuit; full_representation = true)
-  ρ = runcircuit(N, circuit; noise=("amplitude_damping", (γ=0.1,)), full_representation = true)
-  
+  ψ = runcircuit(N, circuit; full_representation=true)
+  ρ = runcircuit(
+    N, circuit; noise=("amplitude_damping", (γ=0.1,)), full_representation=true
+  )
+
   nbases = 11
   bases = randombases(N, nbases)
   data = getsamples(ψ, bases)
-  @test size(data) == (nbases,N)
+  @test size(data) == (nbases, N)
   nshots = 3
   data = getsamples(ψ, bases, nshots)
-  @test size(data) == (nbases*nshots,N)
+  @test size(data) == (nbases * nshots, N)
   for b in 1:nbases
     for k in 1:nshots
-      @test first.(data[(b-1)*nshots+k,:]) == bases[b,:]
+      @test first.(data[(b - 1) * nshots + k, :]) == bases[b, :]
     end
   end
 
   data = getsamples(ρ, bases)
-  @test size(data) == (nbases,N)
+  @test size(data) == (nbases, N)
   nshots = 3
   data = getsamples(ρ, bases, nshots)
-  @test size(data) == (nbases*nshots,N)
+  @test size(data) == (nbases * nshots, N)
   for b in 1:nbases
     for k in 1:nshots
-      @test first.(data[(b-1)*nshots+k,:]) == bases[b,:]
+      @test first.(data[(b - 1) * nshots + k, :]) == bases[b, :]
     end
   end
 end
 
 @testset "getsamples: channels" begin
-
   N = 3
-  circuit = randomcircuit(N; depth = 3)
-  
+  circuit = randomcircuit(N; depth=3)
+
   # quantum processes
-  U = runcircuit(N, circuit; process = true)
-  Λ = runcircuit(N, circuit; noise=("amplitude_damping", (γ=0.1,)), process = true)
-  
+  U = runcircuit(N, circuit; process=true)
+  Λ = runcircuit(N, circuit; noise=("amplitude_damping", (γ=0.1,)), process=true)
+
   npreps = 5
   nbases = 7
   preps = randompreparations(N, npreps)
   bases = randombases(N, nbases)
-  
+
   data = getsamples(U, preps, bases)
-  @test size(data) == (npreps*nbases,N)
+  @test size(data) == (npreps * nbases, N)
   nshots = 3
   data = getsamples(U, preps, bases, nshots)
-  @test size(data) == (npreps*nbases*nshots,N)
-  
+  @test size(data) == (npreps * nbases * nshots, N)
+
   for p in 1:npreps
     for b in 1:nbases
       for k in 1:nshots
-        pdata = first.(data[(p-1)*nbases*nshots+(b-1)*nshots+k,:])
-        bdata = first.(last.(data[(p-1)*nbases*nshots+(b-1)*nshots+k,:]))
-        @test pdata == preps[p,:]
-        @test bdata == bases[b,:]
+        pdata = first.(data[(p - 1) * nbases * nshots + (b - 1) * nshots + k, :])
+        bdata = first.(last.(data[(p - 1) * nbases * nshots + (b - 1) * nshots + k, :]))
+        @test pdata == preps[p, :]
+        @test bdata == bases[b, :]
       end
     end
   end
-  
+
   npreps = 5
   nbases = 5
   preps = randompreparations(N, npreps)
   bases = randombases(N, nbases)
-  
-  data = getsamples(U, preps .=> bases)
-  @test size(data) == (npreps,N)
 
+  data = getsamples(U, preps .=> bases)
+  @test size(data) == (npreps, N)
 
   data = getsamples(Λ, preps, bases)
-  @test size(data) == (npreps*nbases,N)
+  @test size(data) == (npreps * nbases, N)
   nshots = 3
   data = getsamples(Λ, preps, bases, nshots)
-  @test size(data) == (npreps*nbases*nshots,N)
-  
+  @test size(data) == (npreps * nbases * nshots, N)
+
   for p in 1:npreps
     for b in 1:nbases
       for k in 1:nshots
-        pdata = first.(data[(p-1)*nbases*nshots+(b-1)*nshots+k,:])
-        bdata = first.(last.(data[(p-1)*nbases*nshots+(b-1)*nshots+k,:]))
-        @test pdata == preps[p,:]
-        @test bdata == bases[b,:]
+        pdata = first.(data[(p - 1) * nbases * nshots + (b - 1) * nshots + k, :])
+        bdata = first.(last.(data[(p - 1) * nbases * nshots + (b - 1) * nshots + k, :]))
+        @test pdata == preps[p, :]
+        @test bdata == bases[b, :]
       end
     end
   end
-  
+
   npreps = 5
   nbases = 5
   preps = randompreparations(N, npreps)
   bases = randombases(N, nbases)
-  
+
   data = getsamples(Λ, preps .=> bases)
-  @test size(data) == (npreps,N)
+  @test size(data) == (npreps, N)
 
   # full representation
-  U = runcircuit(N, circuit; process = true, full_representation = true)
-  Λ = runcircuit(N, circuit; noise=("amplitude_damping", (γ=0.1,)), process = true,full_representation = true)
-  
+  U = runcircuit(N, circuit; process=true, full_representation=true)
+  Λ = runcircuit(
+    N,
+    circuit;
+    noise=("amplitude_damping", (γ=0.1,)),
+    process=true,
+    full_representation=true,
+  )
+
   npreps = 5
   nbases = 7
   preps = randompreparations(N, npreps)
   bases = randombases(N, nbases)
-  
+
   data = getsamples(U, preps, bases)
-  @test size(data) == (npreps*nbases,N)
+  @test size(data) == (npreps * nbases, N)
   nshots = 3
   data = getsamples(U, preps, bases, nshots)
-  @test size(data) == (npreps*nbases*nshots,N)
-  
+  @test size(data) == (npreps * nbases * nshots, N)
+
   for p in 1:npreps
     for b in 1:nbases
       for k in 1:nshots
-        pdata = first.(data[(p-1)*nbases*nshots+(b-1)*nshots+k,:])
-        bdata = first.(last.(data[(p-1)*nbases*nshots+(b-1)*nshots+k,:]))
-        @test pdata == preps[p,:]
-        @test bdata == bases[b,:]
+        pdata = first.(data[(p - 1) * nbases * nshots + (b - 1) * nshots + k, :])
+        bdata = first.(last.(data[(p - 1) * nbases * nshots + (b - 1) * nshots + k, :]))
+        @test pdata == preps[p, :]
+        @test bdata == bases[b, :]
       end
     end
   end
-  
+
   data = getsamples(Λ, preps, bases)
-  @test size(data) == (npreps*nbases,N)
+  @test size(data) == (npreps * nbases, N)
   nshots = 3
   data = getsamples(Λ, preps, bases, nshots)
-  @test size(data) == (npreps*nbases*nshots,N)
-  
+  @test size(data) == (npreps * nbases * nshots, N)
+
   for p in 1:npreps
     for b in 1:nbases
       for k in 1:nshots
-        pdata = first.(data[(p-1)*nbases*nshots+(b-1)*nshots+k,:])
-        bdata = first.(last.(data[(p-1)*nbases*nshots+(b-1)*nshots+k,:]))
-        @test pdata == preps[p,:]
-        @test bdata == bases[b,:]
+        pdata = first.(data[(p - 1) * nbases * nshots + (b - 1) * nshots + k, :])
+        bdata = first.(last.(data[(p - 1) * nbases * nshots + (b - 1) * nshots + k, :]))
+        @test pdata == preps[p, :]
+        @test bdata == bases[b, :]
       end
     end
   end
 end
-

--- a/test/io.jl
+++ b/test/io.jl
@@ -12,9 +12,9 @@ using Optimisers
   N = 3
   depth = 4
   nshots = 100
-  circuit = randomcircuit(N; depth = depth)
+  circuit = randomcircuit(N; depth=depth)
   path = "test_data_writesamples.h5"
-  
+
   X = runcircuit(circuit)
   data = getsamples(X, nshots)
   writesamples(data, path)
@@ -24,8 +24,8 @@ using Optimisers
   datatest, Xtest = readsamples(path)
   @test X ≈ Xtest
   @test datatest ≈ data
-  
-  X = runcircuit(circuit; noise = ("DEP",(p=0.01,)))
+
+  X = runcircuit(circuit; noise=("DEP", (p=0.01,)))
   data = getsamples(X, nshots)
   writesamples(data, path)
   datatest = readsamples(path)
@@ -34,72 +34,69 @@ using Optimisers
   datatest, Xtest = readsamples(path)
   @test X ≈ Xtest
   @test datatest ≈ data
-  
-  X = randomstate(N; ξ = 2, χ = 3)
+
+  X = randomstate(N; ξ=2, χ=3)
   writesamples(data, X, path)
   datatest, Xtest = readsamples(path)
   @test X.X ≈ Xtest.X
   @test datatest ≈ data
 
-  
   X = runcircuit(circuit)
   bases = randombases(N, 10)
   data = getsamples(X, bases, nshots)
   writesamples(data, path)
   datatest = readsamples(path)
-  @test all(data .== datatest)  
+  @test all(data .== datatest)
   writesamples(data, X, path)
   datatest, Xtest = readsamples(path)
   @test X ≈ Xtest
-  @test all(data .== datatest)  
-  
-  X = runcircuit(circuit; noise = ("DEP",(p=0.01,)))
+  @test all(data .== datatest)
+
+  X = runcircuit(circuit; noise=("DEP", (p=0.01,)))
   bases = randombases(N, 10)
   data = getsamples(X, bases, nshots)
   writesamples(data, path)
   datatest = readsamples(path)
-  @test all(data .== datatest)  
+  @test all(data .== datatest)
   writesamples(data, X, path)
   datatest, Xtest = readsamples(path)
   @test X ≈ Xtest
-  @test all(data .== datatest)  
-  
-  X = randomstate(N; ξ = 2, χ = 3)
+  @test all(data .== datatest)
+
+  X = randomstate(N; ξ=2, χ=3)
   writesamples(data, X, path)
   datatest, Xtest = readsamples(path)
   @test X.X ≈ Xtest.X
-  @test all(data .== datatest)  
-  
+  @test all(data .== datatest)
 
-
-  X = runcircuit(circuit; process = true)
+  X = runcircuit(circuit; process=true)
   preps = randompreparations(N, 8)
   bases = randombases(N, 10)
   data = getsamples(X, preps, bases, nshots)
   writesamples(data, path)
   datatest = readsamples(path)
-  @test all(data .== datatest)  
+  @test all(data .== datatest)
   writesamples(data, X, path)
   datatest, Xtest = readsamples(path)
   @test X ≈ Xtest
-  @test all(data .== datatest)  
-  
-  X = runcircuit(circuit; noise = ("DEP",(p=0.01,)), process = true)
+  @test all(data .== datatest)
+
+  X = runcircuit(circuit; noise=("DEP", (p=0.01,)), process=true)
   preps = randompreparations(N, 8)
   bases = randombases(N, 10)
   data = getsamples(X, preps, bases, nshots)
   writesamples(data, path)
   datatest = readsamples(path)
-  @test all(data .== datatest)  
+  @test all(data .== datatest)
   writesamples(data, X, path)
   datatest, Xtest = readsamples(path)
-  @test all(data .== datatest)  
-  
-  X = randomstate(N; ξ = 2, χ = 3)
+  @test all(data .== datatest)
+
+  X = randomstate(N; ξ=2, χ=3)
   writesamples(data, X, path)
   datatest, Xtest = readsamples(path)
   @test X.X ≈ Xtest.X
-  @test all(data .== datatest)  
+  @test all(data .== datatest)
 end
 
 @testset "circuit observer: MPS" begin
@@ -107,29 +104,36 @@ end
   depth = 9
   R = 5
   Random.seed!(1234)
-  circuit = randomcircuit(N; depth = depth)
+  circuit = randomcircuit(N; depth=depth)
   layer = Tuple[]
-  push!(circuit, [("CX",(1,N)),])
+  push!(circuit, [("CX", (1, N))])
 
   sites = siteinds("Qubit", N)
-  
+
   outputpath = "simulation"
-  ϕ = randomstate(sites; χ = 10, normalize=true)
+  ϕ = randomstate(sites; χ=10, normalize=true)
   ψ = runcircuit(sites, circuit)
-  Ftest = fidelity(ψ,ϕ)
+  Ftest = fidelity(ψ, ϕ)
   f(ψ::MPS; kwargs...) = fidelity(ψ, ϕ)#; kwargs...) = fidelity(ψ, ϕ)
   obs = Observer(["f" => f])
-  ψ = runcircuit(sites, circuit; (observer!)=obs, move_sites_back_before_measurements=true,
-                 outputpath = outputpath, savestate = true, outputlevel = 0)
+  ψ = runcircuit(
+    sites,
+    circuit;
+    (observer!)=obs,
+    move_sites_back_before_measurements=true,
+    outputpath=outputpath,
+    savestate=true,
+    outputlevel=0,
+  )
   @test Ftest ≈ results(obs, "f")[end]
-  @test length(results(obs, "f")) == depth+1
-  
+  @test length(results(obs, "f")) == depth + 1
+
   obs2 = load("simulation_observer.jld2")
-  for (k,v) in obs2
+  for (k, v) in obs2
     @test last(v) ≈ results(obs, k)
   end
 
-  fin = h5open("simulation_state.h5","r")
+  fin = h5open("simulation_state.h5", "r")
   M = read(fin, "state", MPS)
   close(fin)
   @test M ≈ ψ
@@ -140,31 +144,35 @@ end
   depth = 5
   #circuit = Vector{Vector{<:Any}}(undef, depth)
   sites = siteinds("Qubit", N)
-  circuit = randomcircuit(N; depth = depth)
-  
+  circuit = randomcircuit(N; depth=depth)
+
   @disable_warn_order begin
-    L = randomstate(sites; χ = 10, ξ = 3, normalize=true)
+    L = randomstate(sites; χ=10, ξ=3, normalize=true)
     ϱ = MPO(L)
-    ρ = runcircuit(sites, circuit; noise = ("DEP",(p=0.001,)))
-    Ftest = fidelity(ϱ,ρ)
+    ρ = runcircuit(sites, circuit; noise=("DEP", (p=0.001,)))
+    Ftest = fidelity(ϱ, ρ)
     g(ρ::MPO; kwargs...) = fidelity(ρ, ϱ)#; kwargs...) = fidelity(ψ, ϕ)
     obs = Observer(["g" => g])
     outputpath = "simulation"
-    ρ = runcircuit(sites, circuit; 
-                   (observer!)=obs, 
-                   move_sites_back_before_measurements=true, 
-                   outputlevel = 0,
-                   noise = ("DEP",(p=0.001,)),
-                   outputpath = outputpath, savestate = true)
- end
+    ρ = runcircuit(
+      sites,
+      circuit;
+      (observer!)=obs,
+      move_sites_back_before_measurements=true,
+      outputlevel=0,
+      noise=("DEP", (p=0.001,)),
+      outputpath=outputpath,
+      savestate=true,
+    )
+  end
   @test Ftest ≈ results(obs, "g")[end]
   @test length(results(obs, "g")) == depth
   obs2 = load("simulation_observer.jld2")
-  for (k,v) in obs2
+  for (k, v) in obs2
     @test last(v) ≈ results(obs, k)
   end
-  
-  fin = h5open("simulation_state.h5","r")
+
+  fin = h5open("simulation_state.h5", "r")
   M = read(fin, "state", MPO)
   close(fin)
   @test M ≈ ρ
@@ -175,12 +183,12 @@ end
   N = 4
   depth = 4
   nshots = 100
-  circuit = randomcircuit(N; depth = depth)
+  circuit = randomcircuit(N; depth=depth)
   Ψ = runcircuit(circuit)
-  bases = randombases(N,2)
+  bases = randombases(N, 2)
   data = getsamples(Ψ, bases, nshots)
   test_data = copy(data[1:10, :])
-  
+
   N = length(Ψ)     # Number of productstate
   χ = maxlinkdim(Ψ) # Bond dimension of variational MPS
   ψ0 = randomstate(Ψ; χ=χ, σ=0.1)
@@ -201,19 +209,19 @@ end
     batchsize=10,
     epochs=epochs,
     (observer!)=obs,
-    observe_step = observe_step,
-    outputpath = outputpath,
-    savestate = true,
-    outputlevel = 0
-   )
-  @test length(results(obs, "F")) == epochs ÷ observe_step 
+    observe_step=observe_step,
+    outputpath=outputpath,
+    savestate=true,
+    outputlevel=0,
+  )
+  @test length(results(obs, "F")) == epochs ÷ observe_step
 
   obs2 = load("simulation_observer.jld2")
-  for (k,v) in obs2
+  for (k, v) in obs2
     @test last(v) ≈ results(obs, k)
   end
-  
-  fin = h5open("simulation_state.h5","r")
+
+  fin = h5open("simulation_state.h5", "r")
   M = read(fin, "state", MPS)
   close(fin)
   @test M ≈ ψ
@@ -224,15 +232,15 @@ end
   N = 4
   depth = 4
   nshots = 100
-  circuit = randomcircuit(N; depth = depth)
-  ϱ = runcircuit(circuit; noise = ("DEP",(p=0.01,)))
-  bases = randombases(N,2)
+  circuit = randomcircuit(N; depth=depth)
+  ϱ = runcircuit(circuit; noise=("DEP", (p=0.01,)))
+  bases = randombases(N, 2)
   data = getsamples(ϱ, bases, nshots)
   test_data = copy(data[1:10, :])
-  
+
   N = length(ϱ)     # Number of productstate
   χ = maxlinkdim(ϱ) # Bond dimension of variational MPS
-  ρ = randomstate(ϱ; χ=χ÷2, ξ=2)
+  ρ = randomstate(ϱ; χ=χ ÷ 2, ξ=2)
   opt = Optimisers.Descent(0.01)
 
   F(ρ::LPDO; kwargs...) = fidelity(ρ, ϱ)
@@ -250,34 +258,33 @@ end
     batchsize=10,
     epochs=epochs,
     (observer!)=obs,
-    observe_step = observe_step,
-    outputpath = outputpath,
-    savestate = true,
-    outputlevel = 0
+    observe_step=observe_step,
+    outputpath=outputpath,
+    savestate=true,
+    outputlevel=0,
   )
-  @test length(results(obs, "F")) == epochs ÷ observe_step 
+  @test length(results(obs, "F")) == epochs ÷ observe_step
 
   obs2 = load("simulation_observer.jld2")
-  for (k,v) in obs2
+  for (k, v) in obs2
     @test last(v) ≈ results(obs, k)
   end
-  
-  fin = h5open("simulation_state.h5","r")
+
+  fin = h5open("simulation_state.h5", "r")
   M = read(fin, "state", LPDO{MPO})
   close(fin)
   @test M.X ≈ ρ.X
 end
-
 
 @testset "process tomography observer output: MPO" begin
   Random.seed!(1234)
   N = 3
   depth = 4
   nshots = 100
-  circuit = randomcircuit(N; depth =  depth)
-  V = runcircuit(circuit; process = true)
-  preps = randompreparations(N,2)
-  bases = randombases(N,2)
+  circuit = randomcircuit(N; depth=depth)
+  V = runcircuit(circuit; process=true)
+  preps = randompreparations(N, 2)
+  bases = randombases(N, 2)
   data = getsamples(V, preps, bases, nshots)
   test_data = copy(data[1:10, :])
   N = length(V)     # Number of productstate
@@ -300,41 +307,39 @@ end
     batchsize=10,
     epochs=epochs,
     (observer!)=obs,
-    observe_step = observe_step,
-    outputpath = outputpath,
-    savestate = true,
-    outputlevel = 0
-   )
+    observe_step=observe_step,
+    outputpath=outputpath,
+    savestate=true,
+    outputlevel=0,
+  )
 
-  @test length(results(obs, "F")) == epochs ÷ observe_step 
+  @test length(results(obs, "F")) == epochs ÷ observe_step
 
   obs2 = load("simulation_observer.jld2")
-  for (k,v) in obs2
+  for (k, v) in obs2
     @test last(v) ≈ results(obs, k)
   end
-  fin = h5open("simulation_state.h5","r")
+  fin = h5open("simulation_state.h5", "r")
   M = read(fin, "state", MPO)
   close(fin)
   @test M ≈ U
 end
-
-
 
 @testset "state tomography observer output: LPDO" begin
   Random.seed!(1234)
   N = 2
   depth = 4
   nshots = 100
-  circuit = randomcircuit(N; depth = depth)
-  Φ = runcircuit(circuit; process = true, noise = ("DEP",(p=0.01,)))
-  preps = randompreparations(N,2)
-  bases = randombases(N,2)
+  circuit = randomcircuit(N; depth=depth)
+  Φ = runcircuit(circuit; process=true, noise=("DEP", (p=0.01,)))
+  preps = randompreparations(N, 2)
+  bases = randombases(N, 2)
   data = getsamples(Φ, preps, bases, nshots)
   test_data = copy(data[1:10, :])
-  
+
   N = length(Φ)     # Number of productstate
   χ = maxlinkdim(Φ) # Bond dimension of variational MPS
-  Λ = randomprocess(Φ; χ=χ÷2, ξ=2)
+  Λ = randomprocess(Φ; χ=χ ÷ 2, ξ=2)
   opt = Optimisers.Descent(0.01)
 
   F(Λ::LPDO; kwargs...) = fidelity(Λ, Φ)
@@ -352,21 +357,20 @@ end
     batchsize=10,
     epochs=epochs,
     (observer!)=obs,
-    observe_step = observe_step,
-    outputpath = outputpath,
-    savestate = true,
-    outputlevel = 0
+    observe_step=observe_step,
+    outputpath=outputpath,
+    savestate=true,
+    outputlevel=0,
   )
-  @test length(results(obs, "F")) == epochs ÷ observe_step 
+  @test length(results(obs, "F")) == epochs ÷ observe_step
 
   obs2 = load("simulation_observer.jld2")
-  for (k,v) in obs2
+  for (k, v) in obs2
     @test last(v) ≈ results(obs, k)
   end
-  
-  fin = h5open("simulation_state.h5","r")
+
+  fin = h5open("simulation_state.h5", "r")
   M = read(fin, "state", LPDO{MPO})
   close(fin)
   @test M.X ≈ Λ.X
 end
-

--- a/test/noise.jl
+++ b/test/noise.jl
@@ -4,175 +4,172 @@ using Test
 using LinearAlgebra
 using Random
 
-
 @testset "noise models: pauli channel" begin
-  E = gate("pauli_channel") 
-  K = [E[:,:,k] for k in 1:size(E,3)]
-  @test size(E,3) == 4
-  @test sum([E[:,:,k]' * E[:,:,k] for k in 1:size(E,3)]) ≈ Matrix{Float64}(I,2,2)
+  E = gate("pauli_channel")
+  K = [E[:, :, k] for k in 1:size(E, 3)]
+  @test size(E, 3) == 4
+  @test sum([E[:, :, k]' * E[:, :, k] for k in 1:size(E, 3)]) ≈ Matrix{Float64}(I, 2, 2)
   for N in 2:5
     probs = rand(4^N)
     probs = probs ./ sum(probs)
-    E = gate("pauli_channel", Tuple(repeat([2],N)); error_probabilities = probs)
-    @test size(E,3) == 4^N
-    @test sum([E[:,:,k]' * E[:,:,k] for k in 1:size(E,3)]) ≈ Matrix{Float64}(I,1<<N,1<<N)
+    E = gate("pauli_channel", Tuple(repeat([2], N)); error_probabilities=probs)
+    @test size(E, 3) == 4^N
+    @test sum([E[:, :, k]' * E[:, :, k] for k in 1:size(E, 3)]) ≈ Matrix{Float64}(I, 1 << N, 1 << N)
   end
 end
 
 @testset "noise models: bitflip" begin
-  E = gate("bit_flip"; p = 0.1) 
-  K = [E[:,:,k] for k in 1:size(E,3)]
-  @test size(E,3) == 2
-  @test sum([E[:,:,k]' * E[:,:,k] for k in 1:size(E,3)]) ≈ Matrix{Float64}(I,2,2)
+  E = gate("bit_flip"; p=0.1)
+  K = [E[:, :, k] for k in 1:size(E, 3)]
+  @test size(E, 3) == 2
+  @test sum([E[:, :, k]' * E[:, :, k] for k in 1:size(E, 3)]) ≈ Matrix{Float64}(I, 2, 2)
   for N in 2:5
-    E = gate("bit_flip", Tuple(repeat([2],N)); p = 0.1)
-    @test size(E,3) == 2^N
-    @test sum([E[:,:,k]' * E[:,:,k] for k in 1:size(E,3)]) ≈ Matrix{Float64}(I,1<<N,1<<N)
+    E = gate("bit_flip", Tuple(repeat([2], N)); p=0.1)
+    @test size(E, 3) == 2^N
+    @test sum([E[:, :, k]' * E[:, :, k] for k in 1:size(E, 3)]) ≈ Matrix{Float64}(I, 1 << N, 1 << N)
   end
 end
 
 @testset "noise models: phaseflip" begin
-  E = gate("phase_flip"; p = 0.1) 
-  K = [E[:,:,k] for k in 1:size(E,3)]
-  @test size(E,3) == 2
-  @test sum([E[:,:,k]' * E[:,:,k] for k in 1:size(E,3)]) ≈ Matrix{Float64}(I,2,2)
+  E = gate("phase_flip"; p=0.1)
+  K = [E[:, :, k] for k in 1:size(E, 3)]
+  @test size(E, 3) == 2
+  @test sum([E[:, :, k]' * E[:, :, k] for k in 1:size(E, 3)]) ≈ Matrix{Float64}(I, 2, 2)
   for N in 2:5
-    E = gate("phase_flip", Tuple(repeat([2],N)); p = 0.1)
-    @test size(E,3) == 2^N
-    @test sum([E[:,:,k]' * E[:,:,k] for k in 1:size(E,3)]) ≈ Matrix{Float64}(I,1<<N,1<<N)
+    E = gate("phase_flip", Tuple(repeat([2], N)); p=0.1)
+    @test size(E, 3) == 2^N
+    @test sum([E[:, :, k]' * E[:, :, k] for k in 1:size(E, 3)]) ≈ Matrix{Float64}(I, 1 << N, 1 << N)
   end
 end
 
 @testset "noise models: amplitude damping" begin
-  E = gate("AD"; γ = 0.1) 
-  K = [E[:,:,k] for k in 1:size(E,3)]
-  @test size(E,3) == 2
-  @test sum([E[:,:,k]' * E[:,:,k] for k in 1:size(E,3)]) ≈ Matrix{Float64}(I,2,2)
+  E = gate("AD"; γ=0.1)
+  K = [E[:, :, k] for k in 1:size(E, 3)]
+  @test size(E, 3) == 2
+  @test sum([E[:, :, k]' * E[:, :, k] for k in 1:size(E, 3)]) ≈ Matrix{Float64}(I, 2, 2)
   for N in 2:5
-    E = gate("AD", Tuple(repeat([2],N)); γ = 0.1)
-    @test size(E,3) == 2^N
-    @test sum([E[:,:,k]' * E[:,:,k] for k in 1:size(E,3)]) ≈ Matrix{Float64}(I,1<<N,1<<N)
+    E = gate("AD", Tuple(repeat([2], N)); γ=0.1)
+    @test size(E, 3) == 2^N
+    @test sum([E[:, :, k]' * E[:, :, k] for k in 1:size(E, 3)]) ≈ Matrix{Float64}(I, 1 << N, 1 << N)
   end
 
   N = 2
-  circuit1 = randomcircuit(N; depth = 3, layered = false)
+  circuit1 = randomcircuit(N; depth=3, layered=false)
   circuit2 = copy(circuit1)
-  push!(circuit1, ("AD",1,(γ=0.1,)))
-  push!(circuit1, ("AD",2,(γ=0.1,)))
-  push!(circuit2, ("AD",(1,2),(γ=0.1,)))
+  push!(circuit1, ("AD", 1, (γ=0.1,)))
+  push!(circuit1, ("AD", 2, (γ=0.1,)))
+  push!(circuit2, ("AD", (1, 2), (γ=0.1,)))
   ρ₀ = MPO(productstate(N))
-  ρ1 = runcircuit(ρ₀, circuit1) 
+  ρ1 = runcircuit(ρ₀, circuit1)
   ρ2 = runcircuit(ρ₀, circuit2)
   @test PastaQ.array(ρ1) ≈ PastaQ.array(ρ2)
 end
-
 
 @testset "noise models: phase damping" begin
-  E = gate("PD"; γ = 0.1) 
-  K = [E[:,:,k] for k in 1:size(E,3)]
-  @test size(E,3) == 2
-  @test sum([E[:,:,k]' * E[:,:,k] for k in 1:size(E,3)]) ≈ Matrix{Float64}(I,2,2)
+  E = gate("PD"; γ=0.1)
+  K = [E[:, :, k] for k in 1:size(E, 3)]
+  @test size(E, 3) == 2
+  @test sum([E[:, :, k]' * E[:, :, k] for k in 1:size(E, 3)]) ≈ Matrix{Float64}(I, 2, 2)
   for N in 2:5
-    E = gate("PD", Tuple(repeat([2],N)); γ = 0.1)
-    @test size(E,3) == 2^N
-    @test sum([E[:,:,k]' * E[:,:,k] for k in 1:size(E,3)]) ≈ Matrix{Float64}(I,1<<N,1<<N)
+    E = gate("PD", Tuple(repeat([2], N)); γ=0.1)
+    @test size(E, 3) == 2^N
+    @test sum([E[:, :, k]' * E[:, :, k] for k in 1:size(E, 3)]) ≈ Matrix{Float64}(I, 1 << N, 1 << N)
   end
-  
+
   N = 2
-  circuit1 = randomcircuit(N; depth = 3, layered = false)
+  circuit1 = randomcircuit(N; depth=3, layered=false)
   circuit2 = copy(circuit1)
-  push!(circuit1, ("PD",1,(γ=0.1,)))
-  push!(circuit1, ("PD",2,(γ=0.1,)))
-  push!(circuit2, ("PD",(1,2),(γ=0.1,)))
+  push!(circuit1, ("PD", 1, (γ=0.1,)))
+  push!(circuit1, ("PD", 2, (γ=0.1,)))
+  push!(circuit2, ("PD", (1, 2), (γ=0.1,)))
   ρ₀ = MPO(productstate(N))
-  ρ1 = runcircuit(ρ₀, circuit1) 
+  ρ1 = runcircuit(ρ₀, circuit1)
   ρ2 = runcircuit(ρ₀, circuit2)
   @test PastaQ.array(ρ1) ≈ PastaQ.array(ρ2)
 end
 
-
 @testset "noise models: depolarizing" begin
-  E = gate("DEP"; p = 0.1) 
-  K = [E[:,:,k] for k in 1:size(E,3)]
-  @test size(E,3) == 4
-  @test sum([E[:,:,k]' * E[:,:,k] for k in 1:size(E,3)]) ≈ Matrix{Float64}(I,2,2)
+  E = gate("DEP"; p=0.1)
+  K = [E[:, :, k] for k in 1:size(E, 3)]
+  @test size(E, 3) == 4
+  @test sum([E[:, :, k]' * E[:, :, k] for k in 1:size(E, 3)]) ≈ Matrix{Float64}(I, 2, 2)
   for N in 2:5
-    E = gate("DEP", Tuple(repeat([2],N)); p = 0.1)
-    @test size(E,3) == 4^N
-    @test sum([E[:,:,k]' * E[:,:,k] for k in 1:size(E,3)]) ≈ Matrix{Float64}(I,1<<N,1<<N)
+    E = gate("DEP", Tuple(repeat([2], N)); p=0.1)
+    @test size(E, 3) == 4^N
+    @test sum([E[:, :, k]' * E[:, :, k] for k in 1:size(E, 3)]) ≈ Matrix{Float64}(I, 1 << N, 1 << N)
   end
 end
 
 @testset "insertnoise: iid noise" begin
   N = 6
   depth = 4
-  
-  circuit = randomcircuit(N; depth = depth, twoqubitgates = ["CX","CZ"], onequbitgates = ["Rn","X"], layered = false)
+
+  circuit = randomcircuit(
+    N; depth=depth, twoqubitgates=["CX", "CZ"], onequbitgates=["Rn", "X"], layered=false
+  )
   ngates = length(circuit)
-  nCZ,nCX,nR,nX = 0,0,0,0
+  nCZ, nCX, nR, nX = 0, 0, 0, 0
   for g in circuit
-    g[1] == "CX" && (nCX +=1)
-    g[1] == "CZ" && (nCZ +=1)
-    g[1] == "Rn" && (nR +=1)
-    g[1] == "X"  && (nX +=1)
+    g[1] == "CX" && (nCX += 1)
+    g[1] == "CZ" && (nCZ += 1)
+    g[1] == "Rn" && (nR += 1)
+    g[1] == "X" && (nX += 1)
   end
-  
+
   noisemodel = ("DEP", (p=0.01,))
   noisycircuit = insertnoise(circuit, noisemodel)
-  @test length(noisycircuit) == 2*ngates
+  @test length(noisycircuit) == 2 * ngates
   for k in 2:2:length(circuit)
     g = noisycircuit[k]
     @test g[1] == noisemodel[1]
     @test g[3] == noisemodel[2]
   end
-  
-  noisycircuit = insertnoise(circuit, noisemodel; gate = "CX")
+
+  noisycircuit = insertnoise(circuit, noisemodel; gate="CX")
   @test length(noisycircuit) == ngates + nCX
   for k in 1:length(circuit)
     g = noisycircuit[k]
     if g[1] == "CX"
-      @test noisycircuit[k+1][1] == noisemodel[1]
-      @test noisycircuit[k+1][3] == noisemodel[2]
+      @test noisycircuit[k + 1][1] == noisemodel[1]
+      @test noisycircuit[k + 1][3] == noisemodel[2]
     else
-      @test noisycircuit[k+1][1] != noisemodel[1]
+      @test noisycircuit[k + 1][1] != noisemodel[1]
     end
   end
-  noisycircuit = insertnoise(circuit, noisemodel; gate = ["CX","CZ"])
+  noisycircuit = insertnoise(circuit, noisemodel; gate=["CX", "CZ"])
   @test length(noisycircuit) == ngates + nCX + nCZ
- 
 end
-
 
 @testset "insertnoise: one and two qubit noise" begin
   N = 6
   depth = 4
-  
-  circuit = randomcircuit(N; depth = depth, twoqubitgates = ["CX","CZ"], onequbitgates = ["Rn","X"], layered = false)
+
+  circuit = randomcircuit(
+    N; depth=depth, twoqubitgates=["CX", "CZ"], onequbitgates=["Rn", "X"], layered=false
+  )
   ngates = length(circuit)
-  nCZ,nCX,nR,nX = 0,0,0,0
+  nCZ, nCX, nR, nX = 0, 0, 0, 0
   for g in circuit
-    g[1] == "CX" && (nCX +=1)
-    g[1] == "CZ" && (nCZ +=1)
-    g[1] == "Rn" && (nR +=1)
-    g[1] == "X"  && (nX +=1)
+    g[1] == "CX" && (nCX += 1)
+    g[1] == "CZ" && (nCZ += 1)
+    g[1] == "Rn" && (nR += 1)
+    g[1] == "X" && (nX += 1)
   end
-  
+
   noise1Q = ("AD", (γ=0.01,))
   noise2Q = ("DEP", (p=0.05,))
 
-
   noisemodel = (1 => noise1Q, 2 => noise2Q)
   noisycircuit = insertnoise(circuit, noisemodel)
-  @test length(noisycircuit) == 2*ngates
+  @test length(noisycircuit) == 2 * ngates
   for k in 1:2:length(circuit)
     g = noisycircuit[k]
-    if g[2] isa Int 
-      @test noisycircuit[k+1][1] == noise1Q[1]
-      @test noisycircuit[k+1][3] == noise1Q[2]
+    if g[2] isa Int
+      @test noisycircuit[k + 1][1] == noise1Q[1]
+      @test noisycircuit[k + 1][3] == noise1Q[2]
     else
-      @test noisycircuit[k+1][1] == noise2Q[1]
-      @test noisycircuit[k+1][3] == noise2Q[2]
+      @test noisycircuit[k + 1][1] == noise2Q[1]
+      @test noisycircuit[k + 1][3] == noise2Q[2]
     end
   end
 end
-

--- a/test/optimizers.jl
+++ b/test/optimizers.jl
@@ -2,50 +2,48 @@ using PastaQ
 using ITensors
 using Test
 using Random
-import Optimisers
-
+using Optimisers: Optimisers
 
 @testset "Optimizer update" begin
   θ = rand(10)
   ∇ = rand(10)
   θtest = copy(θ)
   opt = Optimisers.Descent(0.01)
-  st  = Optimisers.state(opt, θ)
+  st = Optimisers.state(opt, θ)
   st, θ = Optimisers.update(opt, st, θ, ∇)
-  @test θ ≈ (θtest - 0.01*∇)
+  @test θ ≈ (θtest - 0.01 * ∇)
 end
-
 
 @testset "get/set parameters" begin
   N = 3
-  sites = siteinds("Qubit",N)
-  
+  sites = siteinds("Qubit", N)
+
   # MPS WAVEFUNCTION
-  ψ = randomstate(sites; χ = 4)
+  ψ = randomstate(sites; χ=4)
   θ = PastaQ.getparameters(LPDO(ψ))
-  ϕ = LPDO(randomstate(sites; χ = 4))
+  ϕ = LPDO(randomstate(sites; χ=4))
   @test !(ψ ≈ ϕ.X)
   PastaQ.setparameters!(ϕ, θ)
   @test PastaQ.array(ψ) ≈ PastaQ.array(ϕ.X)
 
   # LPDO (state) 
-  ρ = randomstate(sites; χ = 4, ξ = 3)
+  ρ = randomstate(sites; χ=4, ξ=3)
   θ = PastaQ.getparameters(ρ)
-  σ = randomstate(sites; χ = 4, ξ = 3) 
+  σ = randomstate(sites; χ=4, ξ=3)
   PastaQ.setparameters!(σ, θ)
   @test PastaQ.array(ρ) ≈ PastaQ.array(σ)
-  
+
   # UNITARY 
-  U = LPDO(PastaQ.unitary_mpo_to_choi_mps(randomprocess(sites; χ = 4)))
+  U = LPDO(PastaQ.unitary_mpo_to_choi_mps(randomprocess(sites; χ=4)))
   θ = PastaQ.getparameters(U)
-  V = LPDO(PastaQ.unitary_mpo_to_choi_mps(randomprocess(sites; χ = 4)))
+  V = LPDO(PastaQ.unitary_mpo_to_choi_mps(randomprocess(sites; χ=4)))
   PastaQ.setparameters!(V, θ)
   @test PastaQ.array(U.X) ≈ PastaQ.array(V.X)
 
   # CHOI
-  Λ = randomprocess(sites; χ = 4, ξ = 3)
+  Λ = randomprocess(sites; χ=4, ξ=3)
   θ = PastaQ.getparameters(Λ)
-  Γ = randomprocess(sites; χ = 4, ξ = 3)
+  Γ = randomprocess(sites; χ=4, ξ=3)
   PastaQ.setparameters!(Γ, θ)
   @test PastaQ.array(Γ) ≈ PastaQ.array(Λ)
 end
@@ -57,15 +55,15 @@ end
   data = PastaQ.convertdatapoints(randompreparations(N, nsamples))
 
   ψ = randomstate(N; χ=χ)
-  opt = Optimisers.Descent(0.1) 
+  opt = Optimisers.Descent(0.1)
   st = PastaQ.state(opt, ψ)
   ∇, _ = PastaQ.gradients(LPDO(ψ), data)
-   
+
   ϕ = LPDO(copy(ψ))
-  ϕ = PastaQ.update!(ϕ, ∇, (opt,st)) 
-  ψp = copy(ψ) 
+  ϕ = PastaQ.update!(ϕ, ∇, (opt, st))
+  ψp = copy(ψ)
   for j in 1:N
-    ψp[j] = ψp[j] - 0.1*∇[j]
+    ψp[j] = ψp[j] - 0.1 * ∇[j]
   end
   @test PastaQ.array(ϕ.X) ≈ PastaQ.array(ψp)
 end
@@ -76,16 +74,16 @@ end
   nsamples = 10
   data = PastaQ.convertdatapoints(randompreparations(N, nsamples))
 
-  ρ = randomstate(N; χ=χ,ξ = 2)
-  opt = Optimisers.Descent(0.1) 
+  ρ = randomstate(N; χ=χ, ξ=2)
+  opt = Optimisers.Descent(0.1)
   st = PastaQ.state(opt, ρ)
   ∇, _ = PastaQ.gradients(ρ, data)
-  
+
   γ = copy(ρ)
-  γ = PastaQ.update!(γ, ∇, (opt,st)) 
-  ρp = copy(ρ) 
+  γ = PastaQ.update!(γ, ∇, (opt, st))
+  ρp = copy(ρ)
   for j in 1:N
-    ρp.X[j] = ρp.X[j] - 0.1*∇[j]
+    ρp.X[j] = ρp.X[j] - 0.1 * ∇[j]
   end
   @test PastaQ.array(γ) ≈ PastaQ.array(ρp)
 end
@@ -102,17 +100,17 @@ end
 
   U = randomprocess(N; χ=χ)
   Φ = LPDO(PastaQ.unitary_mpo_to_choi_mps(U))
-  normalize!(Φ; localnorm=2)
-  
-  opt = Optimisers.Descent(0.1) 
+  PastaQ.normalize!(Φ; localnorm=2)
+
+  opt = Optimisers.Descent(0.1)
   st = PastaQ.state(opt, Φ)
   ∇, _ = PastaQ.gradients(Φ, data)
 
   γ = copy(Φ)
-  γ = PastaQ.update!(γ, ∇, (opt,st)) 
-  Φp = copy(Φ) 
+  γ = PastaQ.update!(γ, ∇, (opt, st))
+  Φp = copy(Φ)
   for j in 1:N
-    Φp.X[j] = Φp.X[j] - 0.1*∇[j]
+    Φp.X[j] = Φp.X[j] - 0.1 * ∇[j]
   end
   @test PastaQ.array(γ.X) ≈ PastaQ.array(Φp.X)
 end
@@ -127,20 +125,19 @@ end
   data_out = PastaQ.convertdatapoints(randompreparations(N, nsamples))
   data = data_in .=> data_out
 
-  Λ = randomprocess(N; χ=χ, ξ = 3)
-  normalize!(Λ; localnorm=2)
-  
-  opt = Optimisers.Descent(0.1) 
+  Λ = randomprocess(N; χ=χ, ξ=3)
+  PastaQ.normalize!(Λ; localnorm=2)
+
+  opt = Optimisers.Descent(0.1)
   st = PastaQ.state(opt, Λ)
-  
+
   ∇, _ = PastaQ.gradients(Λ, data)
 
   γ = copy(Λ)
-  γ = PastaQ.update!(γ, ∇, (opt,st)) 
-  Λp = copy(Λ) 
+  γ = PastaQ.update!(γ, ∇, (opt, st))
+  Λp = copy(Λ)
   for j in 1:N
-    Λp.X[j] = Λp.X[j] - 0.1*∇[j]
+    Λp.X[j] = Λp.X[j] - 0.1 * ∇[j]
   end
   @test PastaQ.array(γ) ≈ PastaQ.array(Λp)
 end
-

--- a/test/processtomography.jl
+++ b/test/processtomography.jl
@@ -254,7 +254,7 @@ end
   @test length(Λ) == N
   logZ = 2 * lognorm(Λ.X)
   sqrt_localZ = []
-  normalize!(Λ; (sqrt_localnorms!)=sqrt_localZ, localnorm=2)
+  PastaQ.normalize!(Λ; (sqrt_localnorms!)=sqrt_localZ, localnorm=2)
   @test logZ ≈ N * log(2) + 2.0 * sum(log.(sqrt_localZ))
   @test abs2(norm(Λ.X)) ≈ 2^N
 end
@@ -269,7 +269,7 @@ end
   num_grad = numgradslogZ(Λ)
 
   sqrt_localnorms = []
-  normalize!(Λ; (sqrt_localnorms!)=sqrt_localnorms, localnorm=2)
+  PastaQ.normalize!(Λ; (sqrt_localnorms!)=sqrt_localnorms, localnorm=2)
   @test norm(Λ.X)^2 ≈ 2^N
   alg_grad, _ = PastaQ.gradlogZ(Λ; sqrt_localnorms=sqrt_localnorms)
 
@@ -296,7 +296,7 @@ end
   Λ = LPDO(PastaQ.unitary_mpo_to_choi_mps(U))
   num_grad = numgradsnll(Λ, data)
   sqrt_localnorms = []
-  normalize!(Λ; (sqrt_localnorms!)=sqrt_localnorms, localnorm=2)
+  PastaQ.normalize!(Λ; (sqrt_localnorms!)=sqrt_localnorms, localnorm=2)
 
   alg_grad, _ = PastaQ.gradnll(Λ, data; sqrt_localnorms=sqrt_localnorms)
   for j in 1:N
@@ -316,7 +316,7 @@ end
   num_grad = numgradsTP(Λ; accuracy=1e-8)
   Γ_test = PastaQ.TP(Λ)
   sqrt_localnorms = []
-  normalize!(Λ; (sqrt_localnorms!)=sqrt_localnorms, localnorm=2)
+  PastaQ.normalize!(Λ; (sqrt_localnorms!)=sqrt_localnorms, localnorm=2)
 
   alg_grad_logZ, logZ = PastaQ.gradlogZ(Λ; sqrt_localnorms=sqrt_localnorms)
 
@@ -355,7 +355,7 @@ end
   num_grads = num_gradZ + num_gradNLL + trace_preserving_regularizer * num_gradTP
 
   sqrt_localnorms = []
-  normalize!(Λ; (sqrt_localnorms!)=sqrt_localnorms, localnorm=2)
+  PastaQ.normalize!(Λ; (sqrt_localnorms!)=sqrt_localnorms, localnorm=2)
 
   ex_loss = PastaQ.nll(Λ, data) + 2 * lognorm(Λ.X)
   alg_grads, loss = PastaQ.gradients(
@@ -381,7 +381,7 @@ end
   @test length(Λ) == N
   logZ = logtr(Λ)
   localZ = []
-  normalize!(Λ; (sqrt_localnorms!)=localZ, localnorm=2)
+  PastaQ.normalize!(Λ; (sqrt_localnorms!)=localZ, localnorm=2)
   @test logZ ≈ N * log(2) + 2.0 * sum(log.(localZ))
   @test tr(Λ) ≈ 2^N
 end
@@ -394,7 +394,7 @@ end
   Λ = randomprocess(N; mixed=true, χ=χ, ξ=ξ)
   num_grad = numgradslogZ(Λ)
   sqrt_localnorms = []
-  normalize!(Λ; (sqrt_localnorms!)=sqrt_localnorms, localnorm=2)
+  PastaQ.normalize!(Λ; (sqrt_localnorms!)=sqrt_localnorms, localnorm=2)
   @test tr(Λ) ≈ 2^N
   alg_grad, _ = PastaQ.gradlogZ(Λ; sqrt_localnorms=sqrt_localnorms)
 
@@ -421,7 +421,7 @@ end
   Λ = randomprocess(N; mixed=true, χ=χ, ξ=ξ)
   num_grad = numgradsnll(Λ, data)
   sqrt_localnorms = []
-  normalize!(Λ; (sqrt_localnorms!)=sqrt_localnorms, localnorm=2)
+  PastaQ.normalize!(Λ; (sqrt_localnorms!)=sqrt_localnorms, localnorm=2)
   alg_grad, loss = PastaQ.gradnll(Λ, data; sqrt_localnorms=sqrt_localnorms)
   @test loss ≈ PastaQ.nll(Λ, data)
 
@@ -444,7 +444,7 @@ end
   num_grad = numgradsTP(Λ; accuracy=1e-8)
   Γ_test = PastaQ.TP(Λ)
   sqrt_localnorms = []
-  normalize!(Λ; (sqrt_localnorms!)=sqrt_localnorms, localnorm=2)
+  PastaQ.normalize!(Λ; (sqrt_localnorms!)=sqrt_localnorms, localnorm=2)
   Γ_test = PastaQ.TP(Λ)
 
   alg_grad_logZ, logZ = PastaQ.gradlogZ(Λ; sqrt_localnorms=sqrt_localnorms)
@@ -477,7 +477,7 @@ end
   Λ = randomprocess(N; mixed=true, χ=χ, ξ=ξ)
   num_grad = numgradsnll(Λ, data)
   sqrt_localnorms = []
-  normalize!(Λ; (sqrt_localnorms!)=sqrt_localnorms, localnorm=2)
+  PastaQ.normalize!(Λ; (sqrt_localnorms!)=sqrt_localnorms, localnorm=2)
   alg_grad, loss = PastaQ.gradnll(Λ, data; sqrt_localnorms=sqrt_localnorms)
 
   TP_distance = PastaQ.TP(Λ)
@@ -490,7 +490,7 @@ end
   num_grads = num_gradZ + num_gradNLL + trace_preserving_regularizer * num_gradTP
 
   sqrt_localnorms = []
-  normalize!(Λ; (sqrt_localnorms!)=sqrt_localnorms, localnorm=2)
+  PastaQ.normalize!(Λ; (sqrt_localnorms!)=sqrt_localnorms, localnorm=2)
 
   ex_loss = PastaQ.nll(Λ, data) + 2 * lognorm(Λ.X)
   alg_grads, loss = PastaQ.gradients(
@@ -504,4 +504,3 @@ end
     @test ITensors.array(alg_grads[j]) ≈ num_grads[j] rtol = 1e-3
   end
 end
-

--- a/test/productstates.jl
+++ b/test/productstates.jl
@@ -35,27 +35,26 @@ using Test
   @test productstate(s, fill("Y-", length(s))) ≈ prod(statesYm)
 
   @test productstate(s, n -> isodd(n) ? 1 : 0) ≈
-        states1[1] * states0[2] * states1[3] * states0[4]
+    states1[1] * states0[2] * states1[3] * states0[4]
   @test productstate(s, n -> isodd(n) ? "1" : "0") ≈
-        states1[1] * states0[2] * states1[3] * states0[4]
+    states1[1] * states0[2] * states1[3] * states0[4]
   @test productstate(s, n -> isodd(n) ? "Y-" : "X+") ≈
-        statesYm[1] * statesXp[2] * statesYm[3] * statesXp[4]
+    statesYm[1] * statesXp[2] * statesYm[3] * statesXp[4]
 
   ψ = runcircuit(s, ghz(4))
-  ϕ = productstate(ψ, fill("0", length(s))) ≈ ψ0 
-  
+  ϕ = productstate(ψ, fill("0", length(s))) ≈ ψ0
+
   n = 4
-  ψ = productstate(n; dim = 3)
+  ψ = productstate(n; dim=3)
   @test length(ψ) == n
   @test length(PastaQ.array(ψ)) == 3^n
-  
-  n = 2
-  s = qudits(n; dim = 3)
-  ψ = productstate(n, [0,2]; dim = 3)
-  @test PastaQ.array(ψ) == [0,0,1,0,0,0,0,0,0]
-  ψ = productstate(s, [2,1])
-  @test PastaQ.array(ψ) == [0,0,0,0,0,0,0,1,0]
 
+  n = 2
+  s = qudits(n; dim=3)
+  ψ = productstate(n, [0, 2]; dim=3)
+  @test PastaQ.array(ψ) == [0, 0, 1, 0, 0, 0, 0, 0, 0]
+  ψ = productstate(s, [2, 1])
+  @test PastaQ.array(ψ) == [0, 0, 0, 0, 0, 0, 0, 1, 0]
 end
 
 @testset "productoperator" begin
@@ -68,13 +67,12 @@ end
   @test prod(I) ≈ prod(gatesI)
   @test I ≈ prod(gatesI)
 
-  U = runcircuit(s, ghz(4); process = true)
+  U = runcircuit(s, ghz(4); process=true)
   X = productoperator(U)
   @test X ≈ I
 
-
-  s = qudits(3; dim = 3)
+  s = qudits(3; dim=3)
   X = productoperator(s)
-  @test PastaQ.array(X) ≈ PastaQ.array(productoperator(3; dim = 3))
-  @test PastaQ.array(X) ≈ Matrix(LinearAlgebra.I,27,27)
+  @test PastaQ.array(X) ≈ PastaQ.array(productoperator(3; dim=3))
+  @test PastaQ.array(X) ≈ Matrix(LinearAlgebra.I, 27, 27)
 end

--- a/test/randomstates.jl
+++ b/test/randomstates.jl
@@ -158,12 +158,11 @@ end
   for j in 1:length(N)
     @test firstind(ρ.X[j]; tags="Site", plev=0) == firstind(ρ0.X[j]; tags="Site", plev=0)
   end
-  
-  ψ = randomstate(N; χ = χ, normalize = true)
-  @test norm(ψ) ≈ 1.0
-  ρ = randomstate(N; χ = χ, ξ = 2, normalize = true)
-  @test tr(ρ) ≈ 1.0
 
+  ψ = randomstate(N; χ=χ, normalize=true)
+  @test norm(ψ) ≈ 1.0
+  ρ = randomstate(N; χ=χ, ξ=2, normalize=true)
+  @test tr(ρ) ≈ 1.0
 end
 
 @testset "initialization given a process" begin
@@ -202,10 +201,10 @@ end
     @test firstind(Λ.X[j]; tags="Input") == firstind(Λ0.X[j]; tags="Input")
     @test firstind(Λ.X[j]; tags="Output") == firstind(Λ0.X[j]; tags="Output")
   end
-  
-  U = randomprocess(N; χ = χ, normalize = true)
+
+  U = randomprocess(N; χ=χ, normalize=true)
   Λ = MPO(PastaQ.unitary_mpo_to_choi_mps(U))
   @test tr(Λ) ≈ 1 << N
-  Λ = randomprocess(N; χ = χ, ξ = 2, normalize = true)
+  Λ = randomprocess(N; χ=χ, ξ=2, normalize=true)
   @test tr(Λ) ≈ 1 << N
 end

--- a/test/runcircuit.jl
+++ b/test/runcircuit.jl
@@ -64,61 +64,59 @@ end
 @testset "runcircuit: unitary quantum circuit" begin
   N = 3
   depth = 4
-  gates = randomcircuit(N; depth =  depth, layered=false)
+  gates = randomcircuit(N; depth=depth, layered=false)
   #Pure state, noiseless circuit
   ψ0 = productstate(N)
   ψ = runcircuit(ψ0, gates)
   @test prod(ψ) ≈ runcircuit(prod(ψ0), buildcircuit(ψ0, gates))
   @test PastaQ.array(prod(ψ)) ≈ PastaQ.array(prod(runcircuit(N, gates)))
   @test PastaQ.array(prod(ψ)) ≈ PastaQ.array(prod(runcircuit(gates)))
-  @test PastaQ.array(ψ) ≈ PastaQ.array(runcircuit(gates; full_representation = true))
-  
-  ϕ = runcircuit(ψ0, gates; apply_dag = false)
+  @test PastaQ.array(ψ) ≈ PastaQ.array(runcircuit(gates; full_representation=true))
+
+  ϕ = runcircuit(ψ0, gates; apply_dag=false)
   @test ϕ ≈ ψ
-  σ = runcircuit(ψ0, gates; apply_dag = true)
-  @test σ ≈ outer(ψ,ψ)
+  σ = runcircuit(ψ0, gates; apply_dag=true)
+  @test σ ≈ outer(ψ, ψ)
 
   # Mixed state, noiseless circuit
   ρ0 = MPO(productstate(N))
   ρ = runcircuit(ρ0, gates)
   X = runcircuit(prod(ρ0), buildcircuit(ρ0, gates); apply_dag=true)
   @test prod(ρ) ≈ runcircuit(prod(ρ0), buildcircuit(ρ0, gates); apply_dag=true)
-  @test PastaQ.array(ρ) ≈ PastaQ.array(runcircuit(prod(ρ0),gates; full_representation = true, apply_dag = true))
-  
+  @test PastaQ.array(ρ) ≈
+    PastaQ.array(runcircuit(prod(ρ0), gates; full_representation=true, apply_dag=true))
 end
 
 @testset "choi matrix" begin
   N = 3
   depth = 4
-  circuit = randomcircuit(N; depth =  depth, layered=false)
-  s = siteinds("Qubit",N)
-  Λ = runcircuit(s, circuit; process = true, noise = ("DEP",(p=0.01,)))
+  circuit = randomcircuit(N; depth=depth, layered=false)
+  s = siteinds("Qubit", N)
+  Λ = runcircuit(s, circuit; process=true, noise=("DEP", (p=0.01,)))
   @test PastaQ.ischoi(Λ)
   @test Λ isa MPO
 
-  Φ = choimatrix(circuit; noise = ("DEP",(p=0.01,)))
+  Φ = choimatrix(circuit; noise=("DEP", (p=0.01,)))
   @test PastaQ.ischoi(Φ)
   @test PastaQ.array(Λ) ≈ PastaQ.array(Φ)
   @test Φ isa MPO
 
-  Φ = choimatrix(circuit; noise = ("DEP",(p=0.01,)), full_representation = true)
+  Φ = choimatrix(circuit; noise=("DEP", (p=0.01,)), full_representation=true)
   @test PastaQ.ischoi(Φ)
   @test PastaQ.array(Λ) ≈ PastaQ.array(Φ)
   @test Φ isa ITensor
 
-
-  Φ = choimatrix(circuit; noise = ("DEP",(p=0.01,)), full_representation=true)
+  Φ = choimatrix(circuit; noise=("DEP", (p=0.01,)), full_representation=true)
   @test PastaQ.ischoi(Φ)
   @test PastaQ.array(Λ) ≈ PastaQ.array(Φ)
   @test Φ isa ITensor
-
 end
 
 @testset "runcircuit: (n>2)-qubit gates" begin
   N = 3
   depth = 4
-  gates = randomcircuit(N; depth =  depth, layered=false)
-  push!(gates, ("Toffoli",(1,2,3)))
+  gates = randomcircuit(N; depth=depth, layered=false)
+  push!(gates, ("Toffoli", (1, 2, 3)))
   #Pure state, noiseless circuit
   ψ0 = productstate(N)
   ψ = runcircuit(ψ0, gates)
@@ -135,8 +133,8 @@ end
 @testset "runcircuit: noisy quantum circuit" begin
   N = 5
   depth = 4
-  gates = randomcircuit(N; depth =  depth, layered=false)
-  
+  gates = randomcircuit(N; depth=depth, layered=false)
+
   ψ0 = productstate(N)
   ρ = runcircuit(ψ0, gates; noise=("depolarizing", (p=0.1,)))
   ρ0 = MPO(ψ0)
@@ -149,14 +147,18 @@ end
     ρ = runcircuit(ρ0, gates; noise=("depolarizing", (p=0.1,)))
     U = buildcircuit(ρ0, gates; noise=("depolarizing", (p=0.1,)))
     @test prod(ρ) ≈ runcircuit(prod(ρ0), U; apply_dag=true)
-    @test PastaQ.array(ρ) ≈ PastaQ.tomatrix(runcircuit(gates; noise = ("depolarizing", (p=0.1,)), full_representation = true))
+    @test PastaQ.array(ρ) ≈ PastaQ.tomatrix(
+      runcircuit(gates; noise=("depolarizing", (p=0.1,)), full_representation=true)
+    )
   end
 end
 
 @testset "alternative noise definition" begin
   N = 5
   depth = 4
-  circuit0 = randomcircuit(N; depth =  depth, twoqubitgates="CX", onequbitgates="Rn", layered=false)
+  circuit0 = randomcircuit(
+    N; depth=depth, twoqubitgates="CX", onequbitgates="Rn", layered=false
+  )
   ρ0 = runcircuit(circuit0; noise=("DEP", (p=0.01,)))
 
   ψ = productstate(ρ0)
@@ -172,7 +174,7 @@ end
 
 @testset "runcircuit: inverted gate order" begin
   N = 8
-  gates = randomcircuit(N; depth = 3, layered=false)
+  gates = randomcircuit(N; depth=3, layered=false)
 
   for n in 1:10
     s1 = rand(2:N)
@@ -186,7 +188,7 @@ end
 
 @testset "runcircuit: long range gates" begin
   N = 8
-  gates = randomcircuit(N; depth =  2, layered=false)
+  gates = randomcircuit(N; depth=2, layered=false)
 
   for n in 1:10
     s1 = rand(1:N)
@@ -207,20 +209,17 @@ end
   ψ0 = productstate(N)
 
   Random.seed!(1234)
-  circuit = randomcircuit(N; depth = depth)
+  circuit = randomcircuit(N; depth=depth)
   ψ = runcircuit(ψ0, circuit)
   Random.seed!(1234)
-  circuit = randomcircuit(N; depth = depth)
+  circuit = randomcircuit(N; depth=depth)
   @test prod(ψ) ≈ prod(runcircuit(ψ0, circuit))
-  @test PastaQ.array(ψ) ≈ PastaQ.tovector(runcircuit(circuit; full_representation = true))
+  @test PastaQ.array(ψ) ≈ PastaQ.tovector(runcircuit(circuit; full_representation=true))
 
   Random.seed!(1234)
-  circuit = randomcircuit(N; depth = depth)
+  circuit = randomcircuit(N; depth=depth)
   ρ = runcircuit(ψ0, circuit; noise=("depolarizing", (p=0.1,)))
   Random.seed!(1234)
-  circuit = randomcircuit(N; depth = depth)
+  circuit = randomcircuit(N; depth=depth)
   @test prod(ρ) ≈ prod(runcircuit(ψ0, circuit; noise=("depolarizing", (p=0.1,))))
 end
-
-
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,7 @@ using Test
     "distances.jl",
     "fulltomography.jl",
     "gates.jl",
-    "getsamples.jl", 
+    "getsamples.jl",
     "io.jl",
     "noise.jl",
     "optimizers.jl",

--- a/test/statetomography.jl
+++ b/test/statetomography.jl
@@ -177,7 +177,7 @@ numgradsnll(M::MPS, args...; kwargs...) = numgradsnll(LPDO(M), args...; kwargs..
   @test length(ψ) == N
   logZ = lognorm(ψ)
   localZ = []
-  normalize!(ψ; (localnorms!)=localZ)
+  PastaQ.normalize!(ψ; (localnorms!)=localZ)
   @test logZ ≈ sum(log.(localZ))
   @test norm(ψ) ≈ 1
 end
@@ -196,7 +196,7 @@ end
 
   # 2. Globally normalized
   ψ = randomstate(N; χ=χ)
-  normalize!(ψ)
+  PastaQ.normalize!(ψ)
   @test norm(ψ)^2 ≈ 1
   alg_grad, _ = PastaQ.gradlogZ(ψ)
   num_grad = numgradslogZ(ψ)
@@ -209,7 +209,7 @@ end
   num_grad = numgradslogZ(ψ)
 
   localnorms = []
-  normalize!(ψ; (localnorms!)=localnorms)
+  PastaQ.normalize!(ψ; (localnorms!)=localnorms)
   @test norm(ψ) ≈ 1
   alg_grad, _ = PastaQ.gradlogZ(ψ; localnorms=localnorms)
   for j in 1:N
@@ -234,7 +234,7 @@ end
 
   # 2. Globally normalized
   ψ = randomstate(N; χ=χ)
-  normalize!(ψ)
+  PastaQ.normalize!(ψ)
   num_grad = numgradsnll(ψ, data)
   alg_grad, loss = PastaQ.gradnll(ψ, data)
   for j in 1:N
@@ -245,7 +245,7 @@ end
   ψ = randomstate(N; χ=χ)
   num_grad = numgradsnll(ψ, data)
   localnorms = []
-  normalize!(ψ; (localnorms!)=localnorms)
+  PastaQ.normalize!(ψ; (localnorms!)=localnorms)
   @test norm(ψ) ≈ 1
   alg_grad_localnorm, loss = PastaQ.gradnll(ψ, data; localnorms=localnorms)
   for j in 1:N
@@ -276,7 +276,7 @@ end
 
   # 2. Globally normalized
   ψ = randomstate(N; χ=χ)
-  normalize!(ψ)
+  PastaQ.normalize!(ψ)
   num_gradZ = numgradslogZ(ψ)
   num_gradNLL = numgradsnll(ψ, data)
   num_grads = num_gradZ + num_gradNLL
@@ -297,7 +297,7 @@ end
   num_grads = num_gradZ + num_gradNLL
 
   localnorms = []
-  normalize!(ψ; (localnorms!)=localnorms)
+  PastaQ.normalize!(ψ; (localnorms!)=localnorms)
   NLL = PastaQ.nll(ψ, data)
   ex_loss = NLL
   @test norm(ψ)^2 ≈ 1
@@ -319,7 +319,7 @@ end
   @test length(ρ) == N
   logZ = logtr(ρ)
   localZ = []
-  normalize!(ρ; (sqrt_localnorms!)=localZ)
+  PastaQ.normalize!(ρ; (sqrt_localnorms!)=localZ)
   @test logZ ≈ 2.0 * sum(log.(localZ))
   @test tr(ρ) ≈ 1
 end
@@ -345,7 +345,7 @@ end
 
   # 2. Globally normalized
   ρ = randomstate(N; mixed=true, χ=χ, ξ=ξ)
-  normalize!(ρ)
+  PastaQ.normalize!(ρ)
   @test tr(ρ) ≈ 1
   alg_grad, _ = PastaQ.gradlogZ(ρ)
   num_grad = numgradslogZ(ρ)
@@ -364,7 +364,7 @@ end
   num_grad = numgradslogZ(ρ)
 
   sqrt_localnorms = []
-  normalize!(ρ; (sqrt_localnorms!)=sqrt_localnorms)
+  PastaQ.normalize!(ρ; (sqrt_localnorms!)=sqrt_localnorms)
   @test tr(ρ) ≈ 1
   alg_grad, _ = PastaQ.gradlogZ(ρ; sqrt_localnorms=sqrt_localnorms)
 
@@ -404,7 +404,7 @@ end
 
   ## 2. Globally normalized
   ρ = randomstate(N; mixed=true, χ=χ, ξ=ξ)
-  normalize!(ρ)
+  PastaQ.normalize!(ρ)
   num_grad = numgradsnll(ρ, data)
   alg_grad, loss = PastaQ.gradnll(ρ, data)
 
@@ -421,7 +421,7 @@ end
   ρ = randomstate(N; mixed=true, χ=χ, ξ=ξ)
   num_grad = numgradsnll(ρ, data)
   sqrt_localnorms = []
-  normalize!(ρ; (sqrt_localnorms!)=sqrt_localnorms)
+  PastaQ.normalize!(ρ; (sqrt_localnorms!)=sqrt_localnorms)
   @test tr(ρ) ≈ 1
   alg_grad, loss = PastaQ.gradnll(ρ, data; sqrt_localnorms=sqrt_localnorms)
   alg_gradient = permutedims(ITensors.array(alg_grad[1]), [3, 1, 2])
@@ -433,5 +433,3 @@ end
   alg_gradient = permutedims(ITensors.array(alg_grad[N]), [3, 1, 2])
   @test alg_gradient ≈ num_grad[N] rtol = 1e-3
 end
-
-

--- a/test/trottersuzuki.jl
+++ b/test/trottersuzuki.jl
@@ -6,112 +6,111 @@ using Random
 @testset "trotter circuit: real dynamics" begin
   N = 2
   B = 0.2
-  
-  sites = qubits(N) 
-  
+
+  sites = qubits(N)
+
   ampo = OpSum()
   # loop over the pauli operators
-  for j in 1:N-1
-    ampo += -1.0,"Z",j,"Z",j+1
-    ampo += -B,"X",j
+  for j in 1:(N - 1)
+    ampo += -1.0, "Z", j, "Z", j + 1
+    ampo += -B, "X", j
   end
-  ampo += -B,"X",N
+  ampo += -B, "X", N
   Hmpo = MPO(ampo, sites)
 
   H = OpSum()
   # loop over the pauli operators
-  for j in 1:N-1
-    H += -1.0,"ZZ",(j,j+1)
-    H += -B,"X",j
+  for j in 1:(N - 1)
+    H += -1.0, "ZZ", (j, j + 1)
+    H += -B, "X", j
   end
-  H += -B,"X",N
+  H += -B, "X", N
 
   t = 1.0
   ψ₀ = productstate(sites)
   ψtest = noprime(exp(-im * prod(Hmpo) * t) * prod(ψ₀))
-  
+
   # 1. Specify final time and trotter step
   δt = 0.001
   t = 1.0
-  circuit = trottercircuit(H; δt = δt, t = t)
+  circuit = trottercircuit(H; δt=δt, t=t)
   @test length(circuit) == 1000
   ψ = runcircuit(sites, circuit)
-  @test prod(ψ) ≈ ψtest atol = 1e-5 
+  @test prod(ψ) ≈ ψtest atol = 1e-5
 
   # 2. Specify  a time sequence 
   ts = 0:0.001:1.0
-  circuit = trottercircuit(H; ts = ts)
+  circuit = trottercircuit(H; ts=ts)
   @test length(circuit) == 1000
   ψ = runcircuit(sites, circuit)
-  @test prod(ψ) ≈ ψtest atol = 1e-5 
+  @test prod(ψ) ≈ ψtest atol = 1e-5
   ts = collect(0:0.001:1.0)
-  circuit = trottercircuit(H; ts = ts)
+  circuit = trottercircuit(H; ts=ts)
   @test length(circuit) == 1000
   ψ = runcircuit(sites, circuit)
-  @test prod(ψ) ≈ ψtest atol = 1e-5 
-  
+  @test prod(ψ) ≈ ψtest atol = 1e-5
+
   # 3. Specify a non-uniform time-sequence
   ts = vcat(collect(0:0.001:0.5), collect(0.502:0.002:1.0))
-  circuit = trottercircuit(H; ts = ts)
-  @test length(circuit) == length(ts)-1
+  circuit = trottercircuit(H; ts=ts)
+  @test length(circuit) == length(ts) - 1
   ψ = runcircuit(sites, circuit)
-  @test prod(ψ) ≈ ψtest atol = 1e-5 
+  @test prod(ψ) ≈ ψtest atol = 1e-5
 end
 
 @testset "trotter circuit: imaginary dynamics" begin
   N = 2
   B = 0.2
-  
-  sites = qubits(N) 
-  
+
+  sites = qubits(N)
+
   ampo = OpSum()
   # loop over the pauli operators
-  for j in 1:N-1
-    ampo += -1.0,"Z",j,"Z",j+1
-    ampo += -B,"X",j
+  for j in 1:(N - 1)
+    ampo += -1.0, "Z", j, "Z", j + 1
+    ampo += -B, "X", j
   end
-  ampo += -B,"X",N
+  ampo += -B, "X", N
   Hmpo = MPO(ampo, sites)
 
   H = OpSum()
   # loop over the pauli operators
-  for j in 1:N-1
-    H += -1.0,"ZZ",(j,j+1)
-    H += -B,"X",j
+  for j in 1:(N - 1)
+    H += -1.0, "ZZ", (j, j + 1)
+    H += -B, "X", j
   end
-  H += -B,"X",N
+  H += -B, "X", N
 
   τ = 1.0
   ψ₀ = productstate(sites)
   ψtest = noprime(exp(-prod(Hmpo) * τ) * prod(ψ₀))
-  
+
   ## 1. Specify final time and trotter step
   δτ = 0.001
-  circuit = trottercircuit(H; δτ = δτ, τ = τ)
+  circuit = trottercircuit(H; δτ=δτ, τ=τ)
   @test length(circuit) == 1000
   ψ = runcircuit(sites, circuit)
-  @test prod(ψ) ≈ ψtest atol = 1e-5 
+  @test prod(ψ) ≈ ψtest atol = 1e-5
 
   # 2. Specify  a time sequence 
   τs = 0:0.001:1.0
-  circuit = trottercircuit(H; τs = τs)
+  circuit = trottercircuit(H; τs=τs)
   @test length(circuit) == 1000
   ψ = runcircuit(sites, circuit)
-  @test prod(ψ) ≈ ψtest atol = 1e-5 
+  @test prod(ψ) ≈ ψtest atol = 1e-5
   τs = collect(0:0.001:1.0)
-  circuit = trottercircuit(H; τs = τs)
+  circuit = trottercircuit(H; τs=τs)
   @test length(circuit) == 1000
   ψ = runcircuit(sites, circuit)
-  @test prod(ψ) ≈ ψtest atol = 1e-5 
-  
+  @test prod(ψ) ≈ ψtest atol = 1e-5
+
   # 3. Specify a non-uniform time-sequence
   τs = vcat(collect(0:0.001:0.5), collect(0.502:0.002:1.0))
-  circuit = trottercircuit(H; τs = τs)
-  @test length(circuit) == length(τs)-1
+  circuit = trottercircuit(H; τs=τs)
+  @test length(circuit) == length(τs) - 1
   ψ = runcircuit(sites, circuit)
-  @test prod(ψ) ≈ ψtest atol = 1e-5 
+  @test prod(ψ) ≈ ψtest atol = 1e-5
 end
-
 
 #@testset "trotter layer 1" begin
 #  Random.seed!(1234)
@@ -167,4 +166,3 @@ end
 #    @test g[2] isa Int
 #  end
 #end
-

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -17,7 +17,7 @@ end
 
 @testset "choi tags and MPO/MPS conversion" begin
   N = 4
-  circuit = randomcircuit(4; depth =  4)
+  circuit = randomcircuit(4; depth=4)
 
   U = runcircuit(circuit; process=true)
   ρ = PastaQ.choimatrix(PastaQ.hilbertspace(U), circuit; noise=("DEP", (p=0.01,)))
@@ -56,4 +56,3 @@ end
   @test plev(inds(V[1]; tags="Qubit")[1]) == 1
   @test plev(inds(V[1]; tags="Qubit")[2]) == 0
 end
-


### PR DESCRIPTION
https://github.com/ITensor/ITensors.jl/pull/820 introduces `ITensors.normalize!` (actually an overload of `LinearAlgebra.normalize!`).

Unfortunately the definition there uses the Frobenius norm. I would like to generalize it to allow for other norms, but for now it conflicts with the version in PastaQ. This addresses that issue by changing the notation of the PastaQ `normalize!` that normalizes by the trace (in the case of operators) to the unexported `PastaQ.normalize!`.