### PR TITLE
Fix `nqubits` for gates with a list of sites

### DIFF
--- a/src/circuits/circuits.jl
+++ b/src/circuits/circuits.jl
@@ -1,7 +1,7 @@
 # This makes use of the `ITensors.Ops.Op` type, which
 # automatically parses a gate represented as a Tuple
 # into it's name, sites, and parameters.
-nqubits(gate::Tuple) = maximum(sites(Op(gate)))
+nqubits(gate::Tuple) = maximum(Ops.sites(Op(gate)))
 
 nqubits(gates::Vector) = maximum((nqubits(gate) for gate in gates))
 

--- a/src/circuits/circuits.jl
+++ b/src/circuits/circuits.jl
@@ -1,16 +1,15 @@
-function nqubits(g::Tuple)
-  s = g[2]
-  n = (s isa Number ? s : maximum(s))
-  return n
-end
+# This makes use of the `ITensors.Ops.Op` type, which
+# automatically parses a gate represented as a Tuple
+# into it's name, sites, and parameters.
+nqubits(gate::Tuple) = maximum(sites(Op(gate)))
 
-nqubits(gates::Vector{<:Any}) = maximum((nqubits(gate) for gate in gates))
+nqubits(gates::Vector) = maximum((nqubits(gate) for gate in gates))
 
-nlayers(circuit::Vector{<:Any}) = 1
-nlayers(circuit::Vector{<:Vector{<:Any}}) = length(circuit)
+nlayers(circuit::Vector) = 1
+nlayers(circuit::Vector{<:Vector}) = length(circuit)
 
-ngates(circuit::Vector{<:Any}) = length(circuit)
-ngates(circuit::Vector{<:Vector{<:Any}}) = length(vcat(circuit...))
+ngates(circuit::Vector) = length(circuit)
+ngates(circuit::Vector{<:Vector}) = sum(length, circuit)
 
 """
 --------------------------------------------------------------------------------

--- a/test/gates.jl
+++ b/test/gates.jl
@@ -3,6 +3,15 @@ using ITensors
 using Test
 using LinearAlgebra
 
+@testset "nqubits" begin
+  @test nqubits(("X", 1, 2)) == 2
+  @test nqubits([("X", 1, 2), ("Y", 3, 2)]) == 3
+  @test nqubits(("X", (1, 2))) == 2
+  @test nqubits([("X", (1, 2)), ("Y", 3, 4)]) == 4
+  @test nqubits(("X", (1, 2), (; θ=π/2))) == 2
+  @test nqubits([("X", (1, 2)), ("Y", 3, 4, (; ϕ=2.3))]) == 4
+end
+
 @testset "Gate generation: 1-qubit gates" begin
   i = Index(2, tags = "Qubit")
   


### PR DESCRIPTION
Now this works as expected:
```julia
julia> nqubits([("CX", 1, 2)])
2

julia> nqubits([("CX", (1, 2))])
2
```
Fixes #279 and part of #278.