### PR TITLE
Use fewer allocations and more performant functions in runcircuit

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 PLEASE NOTE THIS IS PRE-RELEASE SOFTWARE
 
 # PastaQ.jl: design and benchmarking quantum hardware
-PastaQ.jl is a Julia software toolbox providing a range of computational methods for quantum computing applications. Some examples are the simulation of quancum circuits, the design of quantum gates, noise characterization and performance benchmarking. PastaQ relies on tensor-network representations of quantum states and processes, and borrows well-refined techniques from the field of machine learning and data science, such as probabilistic modeling and automatic differentiation.
+PastaQ.jl is a Julia software toolbox providing a range of computational methods for quantum computing applications. Some examples are the simulation of quantum circuits, the design of quantum gates, noise characterization and performance benchmarking. PastaQ relies on tensor-network representations of quantum states and processes, and borrows well-refined techniques from the field of machine learning and data science, such as probabilistic modeling and automatic differentiation.
 
 ![alt text](assets/readme_summary.jpg)
 
@@ -67,7 +67,7 @@ gates = [("X" , 1),                              # Pauli X on qubit 1
 #  [4] ((dim=2|id=980|"Qubit,Site,n=4"), (dim=2|id=357|"Link,n=1"))
 ``` 
 
-In this next example, we create a circuit to prepare the GHZ state, and sample projective measurements in the computational basis. We then execture the circuit in the presence of noise, where a local noise channel is applied to each gate. A noise model is described as `noisemodel = ("noisename", (noiseparams...))`, in which case it is applied to each gate identically. To distinguish between one- and two-qubit gates, for example, the following syntax can be used: `noisemodel = (1 => noise1, 2 => noise2)`. For more sophisticated noise models (such as gate-dependent noise), please refer to the documentation. 
+In this next example, we create a circuit to prepare the GHZ state, and sample projective measurements in the computational basis. We then execute the circuit in the presence of noise, where a local noise channel is applied to each gate. A noise model is described as `noisemodel = ("noisename", (noiseparams...))`, in which case it is applied to each gate identically. To distinguish between one- and two-qubit gates, for example, the following syntax can be used: `noisemodel = (1 => noise1, 2 => noise2)`. For more sophisticated noise models (such as gate-dependent noise), please refer to the documentation. 
 
 ```julia
 using PastaQ
@@ -142,10 +142,10 @@ circuit = randomcircuit(n; depth = depth,
 #  maxlinkdim(ψ) = 908
 ```
 
-#### Variational quantum eingensolver
-We show how to perform a ground state search of a many-body hamiltonian $H$ using the variational quantum eigensolver (VQE). The VQE algorithm, based on the variational principle, consists of an iterative optimization of an objective function $\langle \psi(\theta)|H|\psi(\theta)\rangle/\langle\psi(\theta)|\psi(\theta)\rangle$, where $|\psi(\theta)\rangle = U(\theta)|0\rangle$ is the output wavefunction of a parametrized quantum circuit $U(\theta)$. 
+#### Variational quantum eigensolver
+We show how to perform a ground state search of a many-body Hamiltonian $H$ using the variational quantum eigensolver (VQE). The VQE algorithm, based on the variational principle, consists of an iterative optimization of an objective function $\langle \psi(\theta)|H|\psi(\theta)\rangle/\langle\psi(\theta)|\psi(\theta)\rangle$, where $|\psi(\theta)\rangle = U(\theta)|0\rangle$ is the output wavefunction of a parametrized quantum circuit $U(\theta)$. 
 
-In the following example, we consider a quantum Ising model with 10 spins, and perform the optimization by leveraging Automatic Differentiation techniques (AD), provided by the package Zygote.jl. Specifically, we build a variational circuit using built-in circuit-contruction functions, and optimize the expectation value of the Hamiltonian using a gradient-based approach and the LBFGS optimizer. The gradients are evaluated through AD, providing a flexible interface in defining custom variational circuit ansatze.
+In the following example, we consider a quantum Ising model with 10 spins, and perform the optimization by leveraging Automatic Differentiation techniques (AD), provided by the package Zygote.jl. Specifically, we build a variational circuit using built-in circuit-construction functions, and optimize the expectation value of the Hamiltonian using a gradient-based approach and the LBFGS optimizer. The gradients are evaluated through AD, providing a flexible interface in defining custom variational circuit ansatze.
 
 ```julia
 using PastaQ

--- a/src/circuits/runcircuit.jl
+++ b/src/circuits/runcircuit.jl
@@ -125,12 +125,8 @@ function runcircuit(
   # which was added using the `insertnoise` function. If so, one should call directly
   # the `choimatrix` function.
   circuit_tensors = buildcircuit(hilbert, circuit; noise, device, eltype)
-  if circuit_tensors isa Vector{<:ITensor}
-    inds_sizes = [length(inds(g)) for g in circuit_tensors]
-  else
-    inds_sizes = vcat([[length(inds(g)) for g in layer] for layer in circuit_tensors]...)
-  end
-  noiseflag = any(x -> x % 2 == 1, inds_sizes)
+  layers = circuit_tensors isa Vector{<:ITensor} ? (circuit_tensors,) : circuit_tensors
+  noiseflag = any(isodd, (length(inds(g)) for layer in layers for g in layer))
 
   # Unitary operator for the circuit
   if process && !noiseflag


### PR DESCRIPTION
* Use `isodd`. It is more readable and more performant.
* Avoid allocations in a few places
* Correct spelling in the README.

The performance of the code in question has been improved significantly. It was probably not a performance bottle neck. But it's as easy or easier to write non-allocating code (in this case). And the result is more readable (again in this case). So I think its good to promote it as a habit.

I did the following
```julia
any(isodd, (length(inds(g)) for layer in layers for g in layer))
```
An alternative is
```julia
any(isodd, (length(inds(g)) for g in Iterators.flatten(layers)))
```